### PR TITLE
Update documentation for leak tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The tool assumes that, with proper memory management,
 an object's disposal and garbage collection should happen sequentially,
 close to each other.
 
-By monitoring disposal and GC events, the tool detects different types of leaks:
+By monitoring disposal and Garbage Collect events, the tool detects different types of leaks:
 
 - **Not disposed, but GCed (not-disposed)**:
     - a disposable object was GCed,

--- a/README.md
+++ b/README.md
@@ -63,17 +63,19 @@ close to each other.
 
 By monitoring disposal and GC events, the tool detects different types of leaks:
 
-**Not disposed, but GCed (not-disposed)**: a disposable object was GCed,
-without being disposed first. This means that the object's disposable content
-is using memory after the object is no longer needed.
-To fix the leak, invoke `dispose()` to free up the memory.
+- **Not disposed, but GCed (not-disposed)**:
+    - a disposable object was GCed,
+       without being disposed first. This means that the object's disposable content
+       is using memory after the object is no longer needed.
+       To fix the leak, invoke `dispose()` to free up the memory.
 
-**Disposed, but not GCed (not-GCed)**: an object was disposed,
-but not GCed after certain number of GC events. This means that
-a reference to the object is preventing it from being
-garbage collected after it's no longer needed.
-To fix the leak, after disposal assign all reachable references
-of the object to null:
+- **Disposed, but not GCed (not-GCed)**:
+    - an object was disposed,
+       but not GCed after certain number of GC events. This means that
+       a reference to the object is preventing it from being
+       garbage collected after it's no longer needed.
+       To fix the leak, after disposal assign all reachable references
+       of the object to null:
 
 ```
 myField.dispose();

--- a/README.md
+++ b/README.md
@@ -82,14 +82,16 @@ myField.dispose();
 myField = null;
 ```
 
-**Disposed and GCed late (GCed-late)**: an object was disposed and then GCed,
-but GC happened later than expected. This means the retaining path was
-holding the object in memory for some period, but then disappeared.
+- **Disposed and GCed late (GCed-late)**:
+    - an object was disposed and then GCed,
+       but GC happened later than expected. This means the retaining path was
+       holding the object in memory for some period, but then disappeared.
 
-**Disposed, but not GCed, without path (not-GCed-without-path)**: an object
-was disposed and not GCed when expected, but retaining path is not detected,
-that means that the object will be most likely GCed in the next GC cycle,
-and the leak will convert to **GCed-late** leak.
+- **Disposed, but not GCed, without path (not-GCed-without-path)**:
+    - an object
+       was disposed and not GCed when expected, but retaining path is not detected,
+       that means that the object will be most likely GCed in the next GC cycle,
+       and the leak will convert to **GCed-late** leak.
 
 ### Culprits and victims
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ Before reading about leak tracking, understand [Dart memory concepts](https://do
 ### Addressed leak types
 
 The leak tracker can catch only certain types of leaks, in particular, related to timing of disposal and garbage collection.
-
-The tool assumes that, with proper memory management,
-an object's disposal and garbage collection should happen sequentially,
-close to each other. I.e. the object should be garbage collected
+With proper memory management, this tool assumes that, 
+an object's disposal and garbage collection occur in quick succession.
+That is, the object should be garbage collected
 during next garbage collection cycle after disposal.
 
 By monitoring disposal and Garbage Collect events, the tool detects different types of leaks:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The leak tracker will catch leaks only for instrumented objects (See [concepts](
 However, the good news is:
 
 1. Most of disposable Flutter Framework classes are already instrumented. So, Widget related
-leaks in your Flutter application will be cought without additional effort.
+leaks in your Flutter application will be caught without additional effort.
 
 2. If a leak involves at least one instrumented object, the leak will be caught and all
 other objects, even non-instrumented, will stop leaking as well.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
+
+Coming soon! See https://github.com/flutter/devtools/issues/3951.
+
+The text below is under construction.
+
 [![CI](https://github.com/dart-lang/leak_tracker/actions/workflows/ci.yaml/badge.svg)](https://github.com/dart-lang/leak_tracker/actions/workflows/ci.yaml)
 
 # Memory Leak Tracker
 
 This is a framework for memory leak tracking for Dart and Flutter applications.
 
-Coming soon! See https://github.com/flutter/devtools/issues/3951.
+## Quick start to track leaks for Flutter
 
-The text below this sentence is under construction.
-
-## Getting started
-
-To track memory leaks in your Flutter application:
+### Flutter application
 
 1. Before `runApp` invocation, enable leak tracking, and connect the Flutter memory allocation events:
 
@@ -29,6 +30,207 @@ runApp(...
 
 2. Run the application in debug mode and watch for a leak related warnings. If you see a warning, open the link to investigate the leaks.
 
-TODO(polina-c): add example of the warning
+TODO(polina-c): implement the link and add example of the warning.
 
 See more on memory leaks and leak tracking at [Dart memory leak tracker](https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/screens/memory/panes/leaks/LEAK_TRACKING.md).
+
+### Flutter tests
+
+```dart
+test('...', () async {
+  final leaks = await withLeakTracking(
+    () async {
+      ...
+    },
+    throwOnLeaks: false,
+  );
+
+  expect(leaks.total, 0);
+});
+```
+
+## Leak tracking concepts
+
+Before reading about leak tracking, make sure you understand [Dart memory concepts](https://docs.flutter.dev/development/tools/devtools/memory#basic-memory-concepts).
+
+### Leak types
+
+To detect memory leaks, the tool assumes that, with proper memory management,
+an object's disposal and garbage collection should happen sequentially,
+close to each other.
+
+By monitoring disposal and GC events, the tool detects different types of leaks:
+
+**Not disposed, but GCed (not-disposed)**: a disposable object was GCed,
+without being disposed first. This means that the object's disposable content
+is using memory after the object is no longer needed.
+To fix the leak, invoke `dispose()` to free up the memory.
+
+**Disposed, but not GCed (not-GCed)**: an object was disposed,
+but not GCed after certain number of GC events. This means that
+a reference to the object is preventing it from being
+garbage collected after it's no longer needed.
+To fix the leak, after disposal assign all reachable references
+of the object to null:
+
+```
+myField.dispose();
+myField = null;
+```
+
+**Disposed and GCed late (GCed-late)**: an object was disposed and then GCed,
+but GC happened later than expected. This means the retaining path was
+holding the object in memory for some period, but then disappeared.
+
+**Disposed, but not GCed, without path (not-GCed-without-path)**: an object
+was disposed and not GCed when expected, but retaining path is not detected,
+that means that the object will be most likely GCed in the next GC cycle,
+and the leak will convert to **GCed-late** leak.
+
+### Culprits and victims
+
+If you have a set of not-GCed objects, some of them (victims)
+might not be GC-ed because they are held by others (culprits).
+Normally, to fix the leaks, you need to only fix the culprits.
+
+**Victim**: a leaked object, for which the tool could find another
+leaked object that, if fixed, would also fix the first leak.
+
+**Culprit**: a leaked object that is not detected to be the victim
+of another object.
+
+The tool detects which leaked objects are culprits, so you know where to focus.
+
+For example, out of four not-GCed leaks on the following diagram,
+only one is the culprit, because, when the object is fixed
+and GCed, the victims it referenced will be also GCed:
+
+```mermaid
+
+   flowchart TD;
+      l1[leak1\nculprit]
+      l2[leak2\nvictim]
+      l3[leak3\nvictim]
+      l4[leak4\nvictim]
+      l1-->l2;
+      l1-->l3;
+      l2-->l4;
+      l3-->l4;
+```
+
+## Limitations
+
+### By tracked classes
+
+The leak traker will catch leaks only for instrumented onjects (See [concepts](#leak-tracking-concepts) for details).
+
+However, the good news are:
+
+1. Most of disposable Flutter Framework classes are already instrumented. So, Widget related
+leaks in your Flutter application will be cought without additional effort.
+
+2. If a leak involves at least one instrumented object, the leak will be caught and all
+other objects, even non-instrumented, will stop leaking as well.
+
+See [the instrumentation guidance](#instrument-your-code).
+
+### By build mode
+
+The leak tracker availability differs by build bodes. See [Dart build modes](https://github.com/dart-lang/site-www/issues/4436) or [Flutter build modes](https://docs.flutter.dev/testing/build-modes).
+
+#### Dart development and Flutter debug
+
+Leak tracking is fully available.
+
+#### Flutter profile
+
+Leak tracking is available, but MemoryAllocations that listens to Flutter instrumented objects,
+is turned off. See [the guidance](https://github.com/flutter/flutter/blob/15af81782e19ebe7273872f8b07ac71df4e749f2/packages/flutter/lib/src/foundation/memory_allocations.dart#L13) on how to enable it.
+
+#### Dart productive and Flutter release
+
+Leak tracking is disabled. If you are interested in enabling, please, comment [here](https://github.com/dart-lang/leak_tracker/issues/25).
+
+## Instrument your code
+
+If you want to catch leaks for objects outside of Flutter Frameworks,
+that are already instrumented, you need to instrument them.
+
+For each tracked object the library should get two signals from your code:
+(1) the object is created and (2) the object is not in use. Typically the
+first signal is invoked in constractor and the second one in the
+method `dispose`:
+
+```dart
+import 'package:leak_tracker/src/leak_tracker.dart';
+
+class InstrumentedClass {
+  InstrumentedClass() {
+    dispatchObjectCreated(
+      library: library,
+      className: '$InstrumentedClass',
+      object: this,
+    );
+  }
+
+  static const library = 'package:my_package/lib/src/my_lib.dart';
+
+  void dispose() {
+    dispatchObjectDisposed(object: this);
+  }
+}
+```
+
+## Start/stop leak tracking
+
+To start leak tracking, invoke `enableLeakTracking()`, to stop: `disableLeakTracking()`.
+
+TODO(polina-c): note that Flutter Framework enables leak tracking.
+
+
+## Collect leaks
+
+There are two steps in leak collection: (1) get signal that leaks happened
+(leak summary) and (2) get details about the leaks.
+
+### Get leak summary
+
+By default, the leak tracker checks leaks every second, and, if there are some, outputs the
+information to console and sends it to DevTools. Then you can get leak details either by
+requesting them from DevTools or by invoking `collectLeaks()`.
+
+You can change the default by passing customized
+[configuration](https://github.com/dart-lang/leak_tracker/blob/29fa7c0e7fb950c974d15f838636bc97a03a5bcc/lib/src/leak_tracker_model.dart)
+to `enableLeakTracking()`:
+
+1. Disable regular leak checking and check the leaks by calling `checkLeaks()`.
+2. Disable output to console or to DevTools.
+3. Listen to the leaks with custom handler.
+
+See [DevTools guidance] on how to interact with leak tracker.
+
+
+
+
+## Performance impact
+
+### Memory
+
+The Leak Tracker stores a small additional record for each tracked alive object and for each
+detected leak, that increases the memory footprint.
+
+For the [Gallery application](https://github.com/flutter/gallery) in profile mode on `macos`
+the leak tracking increased memory footprint of the home page by ~400 KB that is ~0.5% of
+the total.
+
+### CPU
+
+Leak tracking impacts CPU in two areas:
+
+1. Per object tracking.
+   Added ~0.05 of millisecond (~2.7%) to the total load time of
+   [Gallery](https://github.com/flutter/gallery) home page in profile mode on `macos`.
+
+2. Regular asynchronous analysis of the tracked objects.
+   Took ~2.5 millisectonds for [Gallery](https://github.com/flutter/gallery) home page in
+   profile mode on `macos`.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ and GCed, the victims it referenced will be also GCed:
 
 ### By tracked classes
 
-The leak traker will catch leaks only for instrumented onjects (See [concepts](#leak-tracking-concepts) for details).
+The leak tracker will catch leaks only for instrumented objects (See [concepts](#leak-tracking-concepts) for details).
 
 However, the good news are:
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ and GCed, the victims it referenced will be also GCed:
 
 The leak tracker will catch leaks only for instrumented objects (See [concepts](#leak-tracking-concepts) for details).
 
-However, the good news are:
+However, the good news is:
 
 1. Most of disposable Flutter Framework classes are already instrumented. So, Widget related
 leaks in your Flutter application will be cought without additional effort.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ runApp(...
 
 TODO(polina-c): implement the link and add example of the warning.
 
-See more on memory leaks and leak tracking at [Dart memory leak tracker](https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/screens/memory/panes/leaks/LEAK_TRACKING.md).
-
 ### Flutter tests
+
 
 ```dart
 test('...', () async {
@@ -51,11 +50,13 @@ test('...', () async {
 
 ## Leak tracking concepts
 
-Before reading about leak tracking, make sure you understand [Dart memory concepts](https://docs.flutter.dev/development/tools/devtools/memory#basic-memory-concepts).
+Before reading about leak tracking, understand [Dart memory concepts](https://docs.flutter.dev/development/tools/devtools/memory#basic-memory-concepts).
 
-### Leak types
+### Addressed leak types
 
-To detect memory leaks, the tool assumes that, with proper memory management,
+The leak tracker can catch only certain types of leaks, in particular, related to timing of disposal and garbage collection.
+
+The tool assumes that, with proper memory management,
 an object's disposal and garbage collection should happen sequentially,
 close to each other.
 

--- a/README.md
+++ b/README.md
@@ -196,13 +196,11 @@ when it is the case.
 There are two steps in leak collection: (1) get signal that leaks happened
 (leak summary) and (2) get details about the leaks.
 
-
-
 By default, the leak tracker checks for leaks every second, and, if there are some, outputs the
 summary to console and sends it to DevTools. Then you can get leak details either by
 requesting them from DevTools or by invoking `collectLeaks()` programmatically.
 
-You can change the default by passing customized
+You can change the default behavior by passing customized
 [configuration](https://github.com/dart-lang/leak_tracker/blob/29fa7c0e7fb950c974d15f838636bc97a03a5bcc/lib/src/leak_tracker_model.dart)
 to `enableLeakTracking()`:
 
@@ -210,10 +208,9 @@ to `enableLeakTracking()`:
 2. Disable output to console or to DevTools.
 3. Listen to the leaks with custom handler.
 
-See [DevTools guidance] on how to interact with leak tracker.
+See `DevTools > Memory > Leaks` guidance on how to interact with leak tracker.
 
-
-
+TODO: add link to DevTools documentation.
 
 ## Performance impact
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If you want to catch leaks for objects outside of Flutter Framework,
 (that are already instrumented) you need to instrument them.
 
 For each tracked object the library should get two signals from your code:
-(1) the object is created and (2) the object is not in use. It is most convenient to give first signal in constractor and the second one in the method `dispose`:
+(1) the object is created and (2) the object is not in use. It is most convenient to give the first signal in the constructor and the second one in the `dispose` method:
 
 ```dart
 import 'package:leak_tracker/src/leak_tracker.dart';

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ To start leak tracking, invoke `enableLeakTracking()`, to stop: `disableLeakTrac
 TODO(polina-c): note that Flutter Framework enables leak tracking by default,
 when it is the case.
 
-
 ## Collect leaks
 
 There are two steps in leak collection: (1) get signal that leaks happened

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you want to catch leaks for objects outside of Flutter Framework,
 For each tracked object the library should get two signals from your code:
 (1) the object is created and (2) the object is not in use.
 It is most convenient to give the first signal in the constructor
-and the second one in the `dispose` method:
+and the second signal in the `dispose` method:
 
 ```dart
 import 'package:leak_tracker/src/leak_tracker.dart';

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ TODO(polina-c): implement the link and add example of the warning.
 
 ### Flutter tests
 
+Wrap your tests with `withLeakTracking` to setup automated leak verification:
 
 ```dart
 test('...', () async {
@@ -137,30 +138,30 @@ See [the instrumentation guidance](#instrument-your-code).
 
 ### By build mode
 
-The leak tracker availability differs by build bodes. See [Dart build modes](https://github.com/dart-lang/site-www/issues/4436) or [Flutter build modes](https://docs.flutter.dev/testing/build-modes).
+The leak tracker availability differs by build modes. See [Dart build modes](https://github.com/dart-lang/site-www/issues/4436) or [Flutter build modes](https://docs.flutter.dev/testing/build-modes).
 
-#### Dart development and Flutter debug
+**Dart development and Flutter debug**
 
 Leak tracking is fully available.
 
-#### Flutter profile
+**Flutter profile**
 
 Leak tracking is available, but MemoryAllocations that listens to Flutter instrumented objects,
-is turned off. See [the guidance](https://github.com/flutter/flutter/blob/15af81782e19ebe7273872f8b07ac71df4e749f2/packages/flutter/lib/src/foundation/memory_allocations.dart#L13) on how to enable it.
+should be [turned on](https://github.com/flutter/flutter/blob/15af81782e19ebe7273872f8b07ac71df4e749f2/packages/flutter/lib/src/foundation/memory_allocations.dart#L13) if you want to track Flutter Framework objects.
 
-#### Dart productive and Flutter release
+**Dart productive and Flutter release**
 
-Leak tracking is disabled. If you are interested in enabling, please, comment [here](https://github.com/dart-lang/leak_tracker/issues/25).
+Leak tracking is disabled.
+
+NOTE: If you are interested in enabling leak tracking for release mode, please, comment [here](https://github.com/dart-lang/leak_tracker/issues/25).
 
 ## Instrument your code
 
-If you want to catch leaks for objects outside of Flutter Frameworks,
-that are already instrumented, you need to instrument them.
+If you want to catch leaks for objects outside of Flutter Framework,
+(that are already instrumented) you need to instrument them.
 
 For each tracked object the library should get two signals from your code:
-(1) the object is created and (2) the object is not in use. Typically the
-first signal is invoked in constractor and the second one in the
-method `dispose`:
+(1) the object is created and (2) the object is not in use. It is most convenient to give first signal in constractor and the second one in the method `dispose`:
 
 ```dart
 import 'package:leak_tracker/src/leak_tracker.dart';
@@ -186,7 +187,8 @@ class InstrumentedClass {
 
 To start leak tracking, invoke `enableLeakTracking()`, to stop: `disableLeakTracking()`.
 
-TODO(polina-c): note that Flutter Framework enables leak tracking.
+TODO(polina-c): note that Flutter Framework enables leak tracking by default,
+when it is the case.
 
 
 ## Collect leaks
@@ -194,11 +196,11 @@ TODO(polina-c): note that Flutter Framework enables leak tracking.
 There are two steps in leak collection: (1) get signal that leaks happened
 (leak summary) and (2) get details about the leaks.
 
-### Get leak summary
 
-By default, the leak tracker checks leaks every second, and, if there are some, outputs the
-information to console and sends it to DevTools. Then you can get leak details either by
-requesting them from DevTools or by invoking `collectLeaks()`.
+
+By default, the leak tracker checks for leaks every second, and, if there are some, outputs the
+summary to console and sends it to DevTools. Then you can get leak details either by
+requesting them from DevTools or by invoking `collectLeaks()` programmatically.
 
 You can change the default by passing customized
 [configuration](https://github.com/dart-lang/leak_tracker/blob/29fa7c0e7fb950c974d15f838636bc97a03a5bcc/lib/src/leak_tracker_model.dart)

--- a/README.md
+++ b/README.md
@@ -139,9 +139,8 @@ The leak tracker will catch leaks only for instrumented objects (See [concepts](
 
 However, the good news is:
 
-1. Most of disposable Flutter Framework classes are already instrumented. So, if
-your Flutter application manages widgets in a way that creates leaks, the leaks
-will be caught without additional effort.
+1. Most disposable Flutter Framework classes include instrumentation.
+If how your Flutter app manages widgets results in leaks, Flutter will catch them.
 
 2. If a leak involves at least one instrumented object, the leak will be caught and all
 other objects, even non-instrumented, will stop leaking as well.

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ By monitoring disposal and GC events, the tool detects different types of leaks:
        To fix the leak, after disposal assign all reachable references
        of the object to null:
 
-```
-myField.dispose();
-myField = null;
-```
+    ```
+    myField.dispose();
+    myField = null;
+    ```
 
 - **Disposed and GCed late (GCed-late)**:
     - an object was disposed and then GCed,

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ NOTE: If you are interested in enabling leak tracking for release mode, please, 
 
 ## Instrument your code
 
-If you want to catch leaks for objects outside of Flutter Framework,
-(that are already instrumented) you need to instrument them.
+If you want to catch leaks for objects outside of Flutter Framework
+(that are already instrumented), you need to instrument them.
 
 For each tracked object the library should get two signals from your code:
 (1) the object is created and (2) the object is not in use.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This is a framework for memory leak tracking for Dart and Flutter applications.
 
 ### Flutter application
 
-1. Before `runApp` invocation, enable leak tracking, and connect the Flutter memory allocation events:
+1. Before `runApp` invocation, enable leak tracking, and connect
+the Flutter memory allocation events:
 
 ```dart
 import 'package:flutter/foundation.dart';
@@ -28,7 +29,8 @@ runApp(...
 
 ```
 
-2. Run the application in debug mode and watch for a leak related warnings. If you see a warning, open the link to investigate the leaks.
+2. Run the application in debug mode and watch for a leak related warnings.
+If you see a warning, open the link to investigate the leaks.
 
 TODO(polina-c): implement the link and add example of the warning.
 
@@ -42,10 +44,9 @@ test('...', () async {
     () async {
       ...
     },
-    throwOnLeaks: false,
   );
 
-  expect(leaks.total, 0);
+  expect(leaks, leakFree);
 });
 ```
 
@@ -55,13 +56,15 @@ Before reading about leak tracking, understand [Dart memory concepts](https://do
 
 ### Addressed leak types
 
-The leak tracker can catch only certain types of leaks, in particular, related to timing of disposal and garbage collection.
-With proper memory management, this tool assumes that, 
+The leak tracker can catch only certain types of leaks, in particular,
+related to timing of disposal and garbage collection.
+With proper memory management, this tool assumes that,
 an object's disposal and garbage collection occur in quick succession.
 That is, the object should be garbage collected
 during next garbage collection cycle after disposal.
 
-By monitoring disposal and Garbage Collect events, the tool detects different types of leaks:
+By monitoring disposal and Garbage Collect events, the tool detects
+different types of leaks:
 
 - **Not disposed, but GCed (not-disposed)**:
 
@@ -94,11 +97,16 @@ By monitoring disposal and Garbage Collect events, the tool detects different ty
 
 - **Disposed, but not GCed, without path (not-GCed-without-path)**:
     - **Definition**: an object
-       was disposed and not GCed when expected, but retaining path is not detected,
-       that means that the object will be most likely GCed in the next GC cycle,
+       was disposed and not GCed when expected, but retaining path
+       is not detected,
+       that means that the object will be most likely GCed in
+       the next GC cycle,
        and the leak will convert to **GCed-late** leak.
 
-    - **Fix**: please, [create issue](https://github.com/dart-lang/leak_tracker/issues) if you see this type of leaks, as it means something is wrong with the tool.
+    - **Fix**: please,
+    [create issue](https://github.com/dart-lang/leak_tracker/issues)
+    if you see this type of leaks, as it means
+    something is wrong with the tool.
 
 ### Culprits and victims
 
@@ -135,21 +143,26 @@ and GCed, the victims it referenced will be also GCed:
 
 ### By tracked classes
 
-The leak tracker will catch leaks only for instrumented objects (See [concepts](#leak-tracking-concepts) for details).
+The leak tracker will catch leaks only for instrumented
+objects (See [concepts](#leak-tracking-concepts) for details).
 
 However, the good news is:
 
 1. Most disposable Flutter Framework classes include instrumentation.
-If how your Flutter app manages widgets results in leaks, Flutter will catch them.
+If how your Flutter app manages widgets results in leaks,
+Flutter will catch them.
 
-2. If a leak involves at least one instrumented object, the leak will be caught and all
+2. If a leak involves at least one instrumented object,
+the leak will be caught and all
 other objects, even non-instrumented, will stop leaking as well.
 
 See [the instrumentation guidance](#instrument-your-code).
 
 ### By build mode
 
-The leak tracker availability differs by build modes. See [Dart build modes](https://github.com/dart-lang/site-www/issues/4436) or [Flutter build modes](https://docs.flutter.dev/testing/build-modes).
+The leak tracker availability differs by build modes.
+See [Dart build modes](https://github.com/dart-lang/site-www/issues/4436)
+or [Flutter build modes](https://docs.flutter.dev/testing/build-modes).
 
 **Dart development and Flutter debug**
 
@@ -157,8 +170,10 @@ Leak tracking is fully available.
 
 **Flutter profile**
 
-Leak tracking is available, but MemoryAllocations that listens to Flutter instrumented objects,
-should be [turned on](https://github.com/flutter/flutter/blob/15af81782e19ebe7273872f8b07ac71df4e749f2/packages/flutter/lib/src/foundation/memory_allocations.dart#L13) if you want to track Flutter Framework objects.
+Leak tracking is available, but MemoryAllocations that listens to
+Flutter instrumented objects,
+should be [turned on](https://github.com/flutter/flutter/blob/15af81782e19ebe7273872f8b07ac71df4e749f2/packages/flutter/lib/src/foundation/memory_allocations.dart#L13)
+if you want to track Flutter Framework objects.
 
 **Dart productive and Flutter release**
 
@@ -172,7 +187,9 @@ If you want to catch leaks for objects outside of Flutter Framework,
 (that are already instrumented) you need to instrument them.
 
 For each tracked object the library should get two signals from your code:
-(1) the object is created and (2) the object is not in use. It is most convenient to give the first signal in the constructor and the second one in the `dispose` method:
+(1) the object is created and (2) the object is not in use.
+It is most convenient to give the first signal in the constructor
+and the second one in the `dispose` method:
 
 ```dart
 import 'package:leak_tracker/src/leak_tracker.dart';
@@ -196,7 +213,8 @@ class InstrumentedClass {
 
 ## Start/stop leak tracking
 
-To start leak tracking, invoke `enableLeakTracking()`, to stop: `disableLeakTracking()`.
+To start leak tracking, invoke `enableLeakTracking()`,
+to stop: `disableLeakTracking()`.
 
 TODO(polina-c): note that Flutter Framework enables leak tracking by default,
 when it is the case.
@@ -206,9 +224,12 @@ when it is the case.
 There are two steps in leak collection: (1) get signal that leaks happened
 (leak summary) and (2) get details about the leaks.
 
-By default, the leak tracker checks for leaks every second, and, if there are some, outputs the
-summary to console and sends it to DevTools. Then you can get leak details either by
-requesting them from DevTools or by invoking `collectLeaks()` programmatically.
+By default, the leak tracker checks for leaks every second, and,
+if there are some, outputs the
+summary to console and sends it to DevTools. Then you can get
+leak details either by
+requesting them from DevTools or by invoking `collectLeaks()`
+programmatically.
 
 You can change the default behavior by passing customized
 [configuration](https://github.com/dart-lang/leak_tracker/blob/29fa7c0e7fb950c974d15f838636bc97a03a5bcc/lib/src/leak_tracker_model.dart)
@@ -226,11 +247,14 @@ TODO: add link to DevTools documentation.
 
 ### Memory
 
-The Leak Tracker stores a small additional record for each tracked alive object and for each
+The Leak Tracker stores a small additional record for each
+tracked alive object and for each
 detected leak, that increases the memory footprint.
 
-For the [Gallery application](https://github.com/flutter/gallery) in profile mode on `macos`
-the leak tracking increased memory footprint of the home page by ~400 KB that is ~0.5% of
+For the [Gallery application](https://github.com/flutter/gallery)
+in profile mode on `macos`
+the leak tracking increased memory footprint of the home page
+by ~400 KB that is ~0.5% of
 the total.
 
 ### CPU
@@ -239,8 +263,10 @@ Leak tracking impacts CPU in two areas:
 
 1. Per object tracking.
    Added ~0.05 of millisecond (~2.7%) to the total load time of
-   [Gallery](https://github.com/flutter/gallery) home page in profile mode on `macos`.
+   [Gallery](https://github.com/flutter/gallery) home page
+   in profile mode on `macos`.
 
 2. Regular asynchronous analysis of the tracked objects.
-   Took ~2.5 millisectonds for [Gallery](https://github.com/flutter/gallery) home page in
+   Took ~2.5 millisectonds for
+   [Gallery](https://github.com/flutter/gallery) home page in
    profile mode on `macos`.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ See [the instrumentation guidance](#instrument-your-code).
 ### By build mode
 
 The leak tracker availability differs by build modes.
-See [Dart build modes](https://github.com/dart-lang/site-www/issues/4436)
+See [Dart build modes](https://dart.dev/overview#platform)
 or [Flutter build modes](https://docs.flutter.dev/testing/build-modes).
 
 **Dart development and Flutter debug**
@@ -175,7 +175,7 @@ Flutter instrumented objects,
 should be [turned on](https://github.com/flutter/flutter/blob/15af81782e19ebe7273872f8b07ac71df4e749f2/packages/flutter/lib/src/foundation/memory_allocations.dart#L13)
 if you want to track Flutter Framework objects.
 
-**Dart productive and Flutter release**
+**Dart production and Flutter release**
 
 Leak tracking is disabled.
 


### PR DESCRIPTION
A lot of content is copied from https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/screens/memory/panes/leaks/LEAK_TRACKING.md.

After the PR submission LEAK_TRACKING.md will be deleted.

After tech review, the text should be reviewed with tech writers.

