### PR TITLE
Make leak_tracker install-able on Flutter stable channel

### DIFF
--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 dependencies:
   clock: ^1.1.1
   collection: ^1.15.0
-  intl: ^0.18.1
+  intl: ^0.18.0
   logging: ^1.1.1
   meta: ^1.8.0
   path: ^1.8.3
-  vm_service: '>=11.7.2 <13.0.0'
+  vm_service: '>=11.3.0 <13.0.0'
   web_socket_channel: ^2.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Without this, it errors on flutter 3.10:

```
Resolving dependencies... (3.3s)
Because every version of xxx from path depends on leak_tracker ^6.0.0 which depends on intl ^0.18.1, every version of
  xxx from path requires intl ^0.18.1.
And because every version of xxx from path depends on flutter_localizations from sdk which depends on intl 0.18.0,
  xx from path is incompatible with xx from path.
So, because xx depends on both xx from path and xx from path, version solving failed.
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
  
