### PR TITLE
Improve performance.

### DIFF
--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 8.0.2
 
 * Improve performance.
+* Make gcCountBuffer customizable with default value 3.
 
 # 8.0.1
 

--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.2
+
+* Improve performance.
+
 # 8.0.1
 
 * Handle SentinelException for retaining path.

--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -15,51 +15,24 @@
 # 7.0.8
 
 * Disconnect from service after obtaining retaining paths.
-
-# 7.0.7
-
 * Protect from identityHashCode equal to 0.
 
 # 7.0.6
 
 * Add helpers for troubleshooting.
 * Handle generic arguments for retaining path detection.
-
-# 7.0.5
-
 * Convert to multi-package.
 
 # 7.0.4
 
 * Fix path collection.
 * Create constructor to collect path.
-
-# 7.0.3
-
 * Fix connection issue.
-
-# 7.0.2
-
 * Improve retaining path formatting.
-
-# 7.0.1
-
 * Format retaining path nicely.
-
-# 7.0.0
-
 * Enable collection of retaining path.
-
-# 6.0.3
-
 * Separate testing.
-
-# 6.0.2
-
 * Fixes to support g3.
-
-# 6.0.1
-
 * Fix for MemoryUsageEvent constructor.
 
 # 6.0.0
@@ -102,13 +75,6 @@
 * Breaking changes: update names of types to be align with Flutter naming convention.
 * Add model for Flutter unit testing configuration.
 * Adopt Flutter standard lints.
-
-# 2.0.3
-
-* Improve more documentation.
-
-# 2.0.2
-
 * Improve documentation.
 
 # 2.0.1
@@ -119,45 +85,9 @@
 # 2.0.0
 
 * Breaking changes in `withLeakTracking`.
-
-# 1.0.2
-
 * Refactor test_infra libraries.
-
-# 1.0.1
-
 * Documentation updates.
 
 # 1.0.0
 
 * First release.
-
-# 1.0.0-dev.1.6
-
-* Enable reset for leak tracker.
-
-# 1.0.0-dev.1.5
-
-* Define matcher for leaks.
-
-# 1.0.0-dev.1.4
-
-* Tests and minor fixes.
-
-# 1.0.0-dev.1.3
-
-* Test for `pumpWidget`.
-* Make `disposalTimeBuffer` configurable.
-* Testing API `withLeakTracking`.
-
-# 1.0.0-dev.1.2
-
-* Minor fixes.
-
-# 1.0.0-dev.1.1
-
-* Reorganize example to fit pub.dev standards.
-
-# 1.0.0-dev.1.0
-
-* Create initial structure.

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_gc_counter.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_gc_counter.dart
@@ -10,12 +10,6 @@ class GcCounter {
   int get gcCount => reachabilityBarrier;
 }
 
-/// Delta of GC cycles, enough for a non reachable object to be GCed.
-///
-/// Theoretically, 2 should be enough, however it gives false positives
-/// if there is no activity in the application for ~5 minutes.
-const gcCountBuffer = 3;
-
 /// True, if the disposed object is expected to be GCed,
 /// assuming at the disposal moment it was referenced only
 /// by the the disposal invoker.
@@ -25,6 +19,7 @@ bool shouldObjectBeGced({
   required int currentGcCount,
   required DateTime currentTime,
   required Duration disposalTimeBuffer,
+  required int gcCountBuffer,
 }) =>
     currentGcCount - gcCountAtDisposal >= gcCountBuffer &&
     currentTime.difference(timeAtDisposal) >= disposalTimeBuffer;

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_record.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_record.dart
@@ -116,7 +116,7 @@ class ObjectRecord {
   bool get isGCed => _gcedGcCount != null;
   bool get isDisposed => _disposalGcCount != null;
 
-  bool isGCedLateLeak(Duration disposalTimeBuffer) {
+  bool isGCedLateLeak(Duration disposalTimeBuffer, int gcCountBuffer) {
     if (_disposalGcCount == null || _gcedGcCount == null) return false;
     assert(_gcedTime != null);
     return shouldObjectBeGced(
@@ -125,6 +125,7 @@ class ObjectRecord {
       currentGcCount: _gcedGcCount!,
       currentTime: _gcedTime!,
       disposalTimeBuffer: disposalTimeBuffer,
+      gcCountBuffer: gcCountBuffer,
     );
   }
 
@@ -132,6 +133,7 @@ class ObjectRecord {
     int currentGcCount,
     DateTime currentTime,
     Duration disposalTimeBuffer,
+    int gcCountBuffer,
   ) {
     if (_gcedGcCount != null) return false;
     return shouldObjectBeGced(
@@ -140,6 +142,7 @@ class ObjectRecord {
       currentGcCount: currentGcCount,
       currentTime: currentTime,
       disposalTimeBuffer: disposalTimeBuffer,
+      gcCountBuffer: gcCountBuffer,
     );
   }
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -179,7 +179,11 @@ class ObjectTracker implements LeakProvider {
     final now = clock.now();
     for (int code in _objects.notGCedDisposedOk.toList(growable: false)) {
       if (_notGCed(code).isNotGCedLeak(
-          _gcCounter.gcCount, now, disposalTimeBuffer, gcCountBuffer)) {
+        _gcCounter.gcCount,
+        now,
+        disposalTimeBuffer,
+        gcCountBuffer,
+      )) {
         _objects.notGCedDisposedOk.remove(code);
         _objects.notGCedDisposedLate.add(code);
         objectsToGetPath?.add(code);

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -26,6 +26,7 @@ class ObjectTracker implements LeakProvider {
   ObjectTracker({
     this.leakDiagnosticConfig = const LeakDiagnosticConfig(),
     required this.disposalTimeBuffer,
+    required this.gcCountBuffer,
     FinalizerBuilder? finalizerBuilder,
     GcCounter? gcCounter,
     IdentityHashCoder? coder,
@@ -50,6 +51,8 @@ class ObjectTracker implements LeakProvider {
   bool disposed = false;
 
   final LeakDiagnosticConfig leakDiagnosticConfig;
+
+  final int gcCountBuffer;
 
   void startTracking(
     Object object, {
@@ -90,7 +93,7 @@ class ObjectTracker implements LeakProvider {
     final record = _notGCed(code);
     record.setGCed(_gcCounter.gcCount, clock.now());
 
-    if (record.isGCedLateLeak(disposalTimeBuffer)) {
+    if (record.isGCedLateLeak(disposalTimeBuffer, gcCountBuffer)) {
       _objects.gcedLateLeaks.add(record);
     } else if (record.isNotDisposedLeak) {
       _objects.gcedNotDisposedLeaks.add(record);
@@ -175,8 +178,8 @@ class ObjectTracker implements LeakProvider {
 
     final now = clock.now();
     for (int code in _objects.notGCedDisposedOk.toList(growable: false)) {
-      if (_notGCed(code)
-          .isNotGCedLeak(_gcCounter.gcCount, now, disposalTimeBuffer)) {
+      if (_notGCed(code).isNotGCedLeak(
+          _gcCounter.gcCount, now, disposalTimeBuffer, gcCountBuffer)) {
         _objects.notGCedDisposedOk.remove(code);
         _objects.notGCedDisposedLate.add(code);
         objectsToGetPath?.add(code);

--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracker.dart
@@ -47,6 +47,7 @@ void enableLeakTracking({
     final newTracker = ObjectTracker(
       leakDiagnosticConfig: theConfig.leakDiagnosticConfig,
       disposalTimeBuffer: theConfig.disposalTimeBuffer,
+      gcCountBuffer: theConfig.gcCountBuffer,
     );
 
     _objectTracker.value = newTracker;

--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracker_model.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracker_model.dart
@@ -78,6 +78,15 @@ class LeakDiagnosticConfig {
       classesToCollectStackTraceOnDisposal.contains(classname);
 }
 
+/// The default value for number of full GC cycles, enough for a non reachable object to be GCed.
+///
+/// It is pessimistic assuming that user will want to
+/// detect leaks not more often than a second.
+///
+/// Theoretically, 2 should be enough, however it gives false positives
+/// if there is no activity in the application for ~5 minutes.
+const defaultGcCountBuffer = 3;
+
 class LeakTrackingConfiguration {
   const LeakTrackingConfiguration({
     this.stdoutLeaks = true,
@@ -86,6 +95,7 @@ class LeakTrackingConfiguration {
     this.checkPeriod = const Duration(seconds: 1),
     this.disposalTimeBuffer = const Duration(milliseconds: 100),
     this.leakDiagnosticConfig = const LeakDiagnosticConfig(),
+    this.gcCountBuffer = defaultGcCountBuffer,
   });
 
   /// The leak tracker:
@@ -95,13 +105,18 @@ class LeakTrackingConfiguration {
   /// at the moment of leak checking.
   LeakTrackingConfiguration.passive({
     LeakDiagnosticConfig leakDiagnosticConfig = const LeakDiagnosticConfig(),
+    int gcCountBuffer = defaultGcCountBuffer,
   }) : this(
           stdoutLeaks: false,
           notifyDevTools: false,
           checkPeriod: null,
           disposalTimeBuffer: const Duration(),
           leakDiagnosticConfig: leakDiagnosticConfig,
+          gcCountBuffer: gcCountBuffer,
         );
+
+  /// Number of full GC cycles, enough for a non reachable object to be GCed.
+  final int gcCountBuffer;
 
   final LeakDiagnosticConfig leakDiagnosticConfig;
 
@@ -120,9 +135,6 @@ class LeakTrackingConfiguration {
   final LeakSummaryCallback? onLeaks;
 
   /// Time to allow the disposal invoker to release the reference to the object.
-  ///
-  /// The default value is pessimistic assuming that user will want to
-  /// detect leaks not more often than a second.
   final Duration disposalTimeBuffer;
 }
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
@@ -7,7 +7,6 @@ import 'dart:developer';
 
 import '../shared/shared_model.dart';
 import '_formatting.dart';
-import '_gc_counter.dart';
 import 'leak_tracker.dart';
 import 'leak_tracker_model.dart';
 import 'retaining_path/_connection.dart';

--- a/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
@@ -42,6 +42,9 @@ class MemoryLeaksDetectedError extends StateError {
 /// to wait infinitely for the forced garbage collection, that is needed
 /// to analyse results.
 ///
+/// [gcCountBuffer] is delta of full GC cycles, enough for a non reachable object to be GCed.
+///
+///
 /// If you test Flutter widgets, connect their instrumentation to the leak
 /// tracker:
 /// ```
@@ -76,6 +79,7 @@ Future<Leaks> withLeakTracking(
   Duration? timeoutForFinalGarbageCollection,
   LeakDiagnosticConfig leakDiagnosticConfig = const LeakDiagnosticConfig(),
   AsyncCodeRunner? asyncCodeRunner,
+  int gcCountBuffer = defaultGcCountBuffer,
 }) async {
   if (callback == null) return Leaks({});
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
@@ -147,12 +147,10 @@ Future<void> forceGC({
   final Stopwatch? stopwatch = timeout == null ? null : (Stopwatch()..start());
   final int barrier = reachabilityBarrier;
 
-  final List<List<DateTime>> storage = <List<DateTime>>[];
+  final List<List<int>> storage = <List<int>>[];
 
   void allocateMemory() {
-    storage.add(
-      Iterable<DateTime>.generate(10000, (_) => DateTime.now()).toList(),
-    );
+    storage.add(List.generate(30000, (n) => n));
     if (storage.length > 100) {
       storage.removeAt(0);
     }

--- a/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/orchestration.dart
@@ -41,7 +41,7 @@ class MemoryLeaksDetectedError extends StateError {
 /// to wait infinitely for the forced garbage collection, that is needed
 /// to analyse results.
 ///
-/// [gcCountBuffer] is delta of full GC cycles, enough for a non reachable object to be GCed.
+/// [gcCountBuffer] is number of full GC cycles, enough for a non reachable object to be GCed.
 ///
 ///
 /// If you test Flutter widgets, connect their instrumentation to the leak

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker
-version: 8.0.1
+version: 8.0.2
 description: A framework for memory leak tracking for Dart and Flutter applications.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker
 

--- a/pkgs/leak_tracker/test/debug/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/debug/leak_tracking/orchestration_test.dart
@@ -48,7 +48,7 @@ void main() {
       }
 
       final durationPerRound = sw.elapsed ~/ rounds;
-      expect(durationPerRound.inMilliseconds, lessThan(50));
+      expect(durationPerRound.inMilliseconds, lessThan(100));
     });
   });
 }

--- a/pkgs/leak_tracker/test/debug/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/debug/leak_tracking/orchestration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:leak_tracker/leak_tracker.dart';
 import 'package:test/test.dart';
 
@@ -17,5 +19,36 @@ void main() {
   test('formattedRetainingPath returns path', () async {
     final path = await formattedRetainingPath(myObject.ref);
     expect(path, contains('_test.dart/MyClass:stopwatch'));
+  });
+
+  group('forceGC', () {
+    test('forces gc', () async {
+      Object? myObject = <int>[1, 2, 3, 4, 5];
+      final ref = WeakReference(myObject);
+      myObject = null;
+
+      await forceGC();
+
+      expect(ref.target, null);
+    });
+
+    test('times out', () async {
+      await expectLater(
+        () async => forceGC(timeout: Duration.zero),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('takes reasonable time', () async {
+      const rounds = 100;
+      final sw = Stopwatch()..start();
+
+      for (var _ in Iterable.generate(rounds)) {
+        await forceGC();
+      }
+
+      final durationPerRound = sw.elapsed ~/ rounds;
+      expect(durationPerRound.inMilliseconds, lessThan(50));
+    });
   });
 }

--- a/pkgs/leak_tracker/test/release/leak_tracking/_gc_counter_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/_gc_counter_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:leak_tracker/leak_tracker.dart';
 import 'package:leak_tracker/src/leak_tracking/_gc_counter.dart';
 import 'package:test/test.dart';
 
@@ -18,6 +19,7 @@ void main() {
           currentGcCount: gcNow,
           currentTime: now,
           disposalTimeBuffer: disposalTimeBuffer,
+          gcCountBuffer: defaultGcCountBuffer,
         );
 
     final forJustGcEd = shouldBeGced(gcNow, now);
@@ -31,7 +33,7 @@ void main() {
     expect(forNotEnoughGc, isFalse);
 
     final forEnoughTimeAndGc = shouldBeGced(
-      gcNow - gcCountBuffer,
+      gcNow - defaultGcCountBuffer,
       now.subtract(disposalTimeBuffer),
     );
     expect(forEnoughTimeAndGc, isTrue);

--- a/pkgs/leak_tracker/test/release/leak_tracking/_object_tracker_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/_object_tracker_test.dart
@@ -263,7 +263,7 @@ void main() {
 
       // Time travel.
       time = time.add(_disposalTimeBuffer);
-      gcCounter.gcCount = gcCounter.gcCount + gcCountBuffer;
+      gcCounter.gcCount = gcCounter.gcCount + defaultGcCountBuffer;
 
       await withClock(Clock.fixed(time), () async {
         // Verify notGCed leak is registered.
@@ -293,7 +293,7 @@ void main() {
 
       // Time travel.
       time = time.add(_disposalTimeBuffer);
-      gcCounter.gcCount = gcCounter.gcCount + gcCountBuffer;
+      gcCounter.gcCount = gcCounter.gcCount + defaultGcCountBuffer;
 
       // Verify context for the collected nonGCed.
       await withClock(Clock.fixed(time), () async {
@@ -322,6 +322,7 @@ void main() {
           classesToCollectStackTraceOnDisposal: {'String'},
         ),
         disposalTimeBuffer: _disposalTimeBuffer,
+        gcCountBuffer: defaultGcCountBuffer,
       );
     });
 
@@ -342,7 +343,7 @@ void main() {
 
       // Time travel.
       time = time.add(_disposalTimeBuffer);
-      gcCounter.gcCount = gcCounter.gcCount + gcCountBuffer;
+      gcCounter.gcCount = gcCounter.gcCount + defaultGcCountBuffer;
 
       // GC and verify leak contains callstacks.
       await withClock(Clock.fixed(time), () async {

--- a/pkgs/leak_tracker/test/release/leak_tracking/_object_tracker_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/_object_tracker_test.dart
@@ -80,6 +80,7 @@ void main() {
       tracker = ObjectTracker(
         disposalTimeBuffer: _disposalTimeBuffer,
         coder: mockCoder,
+        gcCountBuffer: defaultGcCountBuffer,
       );
     });
 
@@ -145,6 +146,7 @@ void main() {
         finalizerBuilder: finalizerBuilder.build,
         gcCounter: gcCounter,
         disposalTimeBuffer: _disposalTimeBuffer,
+        gcCountBuffer: defaultGcCountBuffer,
       );
     });
 
@@ -169,7 +171,7 @@ void main() {
 
       // Time travel.
       time = time.add(_disposalTimeBuffer * 1000);
-      gcCounter.gcCount = gcCounter.gcCount + gcCountBuffer * 1000;
+      gcCounter.gcCount = gcCounter.gcCount + defaultGcCountBuffer * 1000;
 
       // Verify no leaks.
       withClock(Clock.fixed(time), () {
@@ -210,7 +212,7 @@ void main() {
 
       // Time travel.
       time = time.add(_disposalTimeBuffer);
-      gcCounter.gcCount = gcCounter.gcCount + gcCountBuffer;
+      gcCounter.gcCount = gcCounter.gcCount + defaultGcCountBuffer;
 
       // Verify leak is registered.
       await withClock(Clock.fixed(time), () async {
@@ -235,7 +237,7 @@ void main() {
 
       // Time travel.
       time = time.add(_disposalTimeBuffer);
-      gcCounter.gcCount = gcCounter.gcCount + gcCountBuffer;
+      gcCounter.gcCount = gcCounter.gcCount + defaultGcCountBuffer;
 
       // GC and verify leak is registered.
       await withClock(Clock.fixed(time), () async {

--- a/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
@@ -49,7 +49,7 @@ void main() {
       }
 
       final durationPerRound = sw.elapsed ~/ rounds;
-      expect(durationPerRound.inMilliseconds, lessThan(50));
+      expect(durationPerRound.inMilliseconds, lessThan(100));
     });
   });
 }

--- a/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:leak_tracker/src/leak_tracking/_gc_counter.dart';
 import 'package:leak_tracker/src/leak_tracking/orchestration.dart';
 import 'package:test/test.dart';
 
@@ -22,20 +23,32 @@ void main() {
     await withLeakTracking(() async {});
   });
 
-  test('forceGC forces gc', () async {
-    Object? myObject = <int>[1, 2, 3, 4, 5];
-    final ref = WeakReference(myObject);
-    myObject = null;
+  group('forceGC', () {
+    test('forces gc', () async {
+      Object? myObject = <int>[1, 2, 3, 4, 5];
+      final ref = WeakReference(myObject);
+      myObject = null;
 
-    await forceGC();
+      await forceGC();
 
-    expect(ref.target, null);
-  });
+      expect(ref.target, null);
+    });
 
-  test('forceGC times out', () async {
-    await expectLater(
-      forceGC(timeout: Duration.zero),
-      throwsA(isA<TimeoutException>()),
-    );
+    test('forces gc', () async {
+      Object? myObject = <int>[1, 2, 3, 4, 5];
+      final ref = WeakReference(myObject);
+      myObject = null;
+
+      await forceGC();
+
+      expect(ref.target, null);
+    });
+
+    test('times out', () async {
+      await expectLater(
+        forceGC(timeout: Duration.zero),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
   });
 }

--- a/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
@@ -33,21 +33,23 @@ void main() {
       expect(ref.target, null);
     });
 
-    test('forces gc', () async {
-      Object? myObject = <int>[1, 2, 3, 4, 5];
-      final ref = WeakReference(myObject);
-      myObject = null;
-
-      await forceGC();
-
-      expect(ref.target, null);
-    });
-
     test('times out', () async {
       await expectLater(
-        forceGC(timeout: Duration.zero),
+        () async => forceGC(timeout: Duration.zero),
         throwsA(isA<TimeoutException>()),
       );
+    });
+
+    test('takes reasonable time', () async {
+      const rounds = 100;
+      final sw = Stopwatch()..start();
+
+      for (var _ in Iterable.generate(rounds)) {
+        await forceGC();
+      }
+
+      final durationPerRound = sw.elapsed ~/ rounds;
+      expect(durationPerRound.inMilliseconds, lessThan(50));
     });
   });
 }

--- a/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/release/leak_tracking/orchestration_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:leak_tracker/src/leak_tracking/_gc_counter.dart';
 import 'package:leak_tracker/src/leak_tracking/orchestration.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/leak_tracker/test/test_infra/mocks/mock_object_tracker.dart
+++ b/pkgs/leak_tracker/test/test_infra/mocks/mock_object_tracker.dart
@@ -24,6 +24,7 @@ class MockObjectTracker extends ObjectTracker {
       : super(
           disposalTimeBuffer: const Duration(milliseconds: 100),
           leakDiagnosticConfig: const LeakDiagnosticConfig(),
+          gcCountBuffer: defaultGcCountBuffer,
         );
 
   final events = <Event>[];

--- a/pkgs/leak_tracker_flutter_test/test/test_infra/mock_object_tracker.dart
+++ b/pkgs/leak_tracker_flutter_test/test/test_infra/mock_object_tracker.dart
@@ -24,6 +24,7 @@ class MockObjectTracker extends ObjectTracker {
       : super(
           disposalTimeBuffer: const Duration(milliseconds: 100),
           leakDiagnosticConfig: const LeakDiagnosticConfig(),
+          gcCountBuffer: 3,
         );
 
   final events = <Event>[];


### PR DESCRIPTION
1. Enabled customization for gcCountBuffer, so that tests can use value 1 instead of 3.
2. Fine tuned a way to allocate memory in forceGC, to make it working faster
3. Test covered performance of forceGC

Also removed non published versions from changelog.
 