### PR TITLE
Fix issue of using wrong settings for a phase.

### DIFF
--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.5
+
+* Fix issue of using wrong settings for a phase.
+
 # 9.0.4
 
 * Make it possible to disable tracking for a type of leak.

--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 9.0.5
 
-* Fix issue of using wrong settings for a phase.
+* Fix issue of using wrong settings for a phase, so that the tracker uses settings
+at time of object tracking start, instead of current configuration.
 
 # 9.0.4
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_leak_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_leak_tracker.dart
@@ -13,7 +13,6 @@ class LeakTracker {
       disposalTime: config.disposalTime,
       numberOfGcCycles: config.numberOfGcCycles,
       maxRequestsForRetainingPath: config.maxRequestsForRetainingPath,
-      phase: phase,
       switches: config.switches,
     );
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -165,7 +165,7 @@ class ObjectTracker implements LeakProvider {
   @override
   Future<LeakSummary> leaksSummary() async {
     throwIfDisposed();
-    await _checkForNewNotGCedLeaks();
+    await _checkForNewNotGCedLeaks(summary: true);
 
     return LeakSummary({
       LeakType.notDisposed: _objects.gcedNotDisposedLeaks.length,
@@ -174,11 +174,12 @@ class ObjectTracker implements LeakProvider {
     });
   }
 
-  Future<void> _checkForNewNotGCedLeaks() async {
+  Future<void> _checkForNewNotGCedLeaks({bool summary = false}) async {
     _objects.assertIntegrity();
 
     final List<int>? objectsToGetPath =
-        phase.value.leakDiagnosticConfig.collectRetainingPathForNotGCed
+        phase.value.leakDiagnosticConfig.collectRetainingPathForNotGCed &&
+                !summary
             ? []
             : null;
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
@@ -124,6 +124,7 @@ abstract class LeakTracking {
         context: context,
         trackedClass:
             fullClassName(library: library, shortClassName: className),
+        phase: _phase.value,
       );
 
       return true;

--- a/pkgs/leak_tracker/lib/src/shared/_util.dart
+++ b/pkgs/leak_tracker/lib/src/shared/_util.dart
@@ -32,6 +32,13 @@ T cast<T>(value) {
   );
 }
 
+extension IterableExtensions<T> on Iterable<T> {
+  T? get onlyOrNull {
+    if (length > 1) throw StateError('Lenth should not be more than one.');
+    return firstOrNull;
+  }
+}
+
 void printToConsole(Object message) {
   // ignore: avoid_print, dart:io is not available in web
   print('leak_tracker: $message');

--- a/pkgs/leak_tracker/lib/src/shared/_util.dart
+++ b/pkgs/leak_tracker/lib/src/shared/_util.dart
@@ -33,6 +33,9 @@ T cast<T>(value) {
 }
 
 extension IterableExtensions<T> on Iterable<T> {
+  /// Returns the item or null, assuming that the length of the itrable os 0 or 1.
+  // The name is consistent woth other methods names on iterable like
+  // `firstOrNull, lastOrNull and singleOrNull`.
   T? get onlyOrNull {
     if (length > 1) throw StateError('Lenth should not be more than one.');
     return firstOrNull;

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker
-version: 9.0.4
+version: 9.0.5
 description: A framework for memory leak tracking for Dart and Flutter applications.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker
 

--- a/pkgs/leak_tracker/test/test_infra/data/dart_classes.dart
+++ b/pkgs/leak_tracker/test/test_infra/data/dart_classes.dart
@@ -4,6 +4,12 @@
 
 import 'package:leak_tracker/leak_tracker.dart';
 
+class Named {
+  Named(this.name);
+
+  final String name;
+}
+
 class LeakTrackedClass {
   LeakTrackedClass() {
     LeakTracking.dispatchObjectCreated(

--- a/pkgs/leak_tracker/test/test_infra/mocks/mock_object_tracker.dart
+++ b/pkgs/leak_tracker/test/test_infra/mocks/mock_object_tracker.dart
@@ -4,7 +4,6 @@
 
 import 'package:leak_tracker/leak_tracker.dart';
 import 'package:leak_tracker/src/leak_tracking/_object_tracker.dart';
-import 'package:leak_tracker/src/shared/_primitives.dart';
 
 enum EventType {
   started,

--- a/pkgs/leak_tracker/test/test_infra/mocks/mock_object_tracker.dart
+++ b/pkgs/leak_tracker/test/test_infra/mocks/mock_object_tracker.dart
@@ -26,7 +26,6 @@ class MockObjectTracker extends ObjectTracker {
           disposalTime: const Duration(milliseconds: 100),
           numberOfGcCycles: defaultNumberOfGcCycles,
           maxRequestsForRetainingPath: 0,
-          phase: ObjectRef(const PhaseSettings()),
           switches: const Switches(),
         );
 
@@ -37,6 +36,7 @@ class MockObjectTracker extends ObjectTracker {
     Object object, {
     required Map<String, dynamic>? context,
     required String trackedClass,
+    required PhaseSettings phase,
   }) =>
       events.add(Event(EventType.started, object, context, trackedClass));
 

--- a/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
@@ -426,7 +426,7 @@ void main() {
         object,
         trackedClass: _trackedClass,
         context: null,
-        phase: const PhaseSettings.paused(),
+        phase: phase,
       );
     }
 
@@ -526,11 +526,14 @@ void main() {
             'when objects are tracked with different settings, disposed=$disposed, gced=$gced.',
             () async {
           for (var object in objectsToPhases.keys) {
+            final phase = objectsToPhases[object]!;
+            print('1 started $object, ${phase.name}, ${phase.isPaused}');
             // Start tracking.
-            startTracking(object, objectsToPhases[object]!);
+            startTracking(object, phase);
           }
 
           for (var object in objectsToPhases.keys) {
+            print('finished $object');
             // Dispose and garbage collect.
             if (disposed) tracker.dispatchDisposal(object, context: null);
             if (gced) finalizerBuilder.gc(object);

--- a/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
@@ -514,8 +514,14 @@ void main() {
       );
     }
 
-    for (var gced in [true, false]) {
-      for (var disposed in [true, false]) {
+    for (var gced in [
+      true,
+      //false,
+    ]) {
+      for (var disposed in [
+        //true,
+        false,
+      ]) {
         test(
             'when objects are tracked with different settings, disposed=$disposed, gced=$gced.',
             () async {

--- a/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:clock/clock.dart';
 import 'package:leak_tracker/leak_tracker.dart';
 import 'package:leak_tracker/src/leak_tracking/_object_tracker.dart';
@@ -161,8 +159,12 @@ void main() {
 
     test('uses finalizer.', () {
       const theObject = '-';
-      tracker.startTracking(theObject,
-          context: null, trackedClass: '', phase: const PhaseSettings());
+      tracker.startTracking(
+        theObject,
+        context: null,
+        trackedClass: '',
+        phase: const PhaseSettings(),
+      );
       expect(
         finalizerBuilder.finalizer.attached,
         contains(identityHashCode(theObject)),
@@ -470,7 +472,7 @@ void main() {
       }
       leak = leak!;
 
-      expect(leak.phase, phase);
+      expect(leak.phase, phase.name);
 
       checkContext(
         leak.context,
@@ -527,13 +529,11 @@ void main() {
             () async {
           for (var object in objectsToPhases.keys) {
             final phase = objectsToPhases[object]!;
-            print('1 started $object, ${phase.name}, ${phase.isPaused}');
             // Start tracking.
             startTracking(object, phase);
           }
 
           for (var object in objectsToPhases.keys) {
-            print('finished $object');
             // Dispose and garbage collect.
             if (disposed) tracker.dispatchDisposal(object, context: null);
             if (gced) finalizerBuilder.gc(object);


### PR DESCRIPTION
Instead of using settings for current phase, ObjectTracker should use settings for a phase associated with the tracked object.