### PR TITLE
Fix flakiness in detection of notDisposed leaks in tests. 

### DIFF
--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.8
+
+* Enable declaring all not disposed objects as leaks.
+
 # 9.0.7
 
 * Use ObjectRecord instead of hash code to identify objects.

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_record_set.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_record_set.dart
@@ -32,8 +32,10 @@ class ObjectRecordSet {
     return list.firstWhereOrNull((r) => r.ref.target == object);
   }
 
+  /// Removes record if it exists in the set.
   void remove(ObjectRecord record) {
-    final list = _records[record.code]!;
+    final list = _records[record.code];
+    if (list == null) return;
     bool removed = false;
     list.removeWhere((r) {
       if (r == record) {
@@ -42,7 +44,6 @@ class ObjectRecordSet {
       }
       return r == record;
     });
-    assert(removed);
     _length--;
     if (list.isEmpty) _records.remove(record.code);
   }

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -107,7 +107,7 @@ class ObjectTracker implements LeakProvider {
   /// Is used to make sure all disposables are disposed by the the end of the test.
   void declareAllNotDisposedAsLeaks() {
     throwIfDisposed();
-    // We need this temporary storage to avoid errror 'concurrent modification during iteration'
+    // We need this temporary storage to avoid error 'concurrent modification during iteration'
     // for internal iterables in `_objects.notGCed`.
     final notGCedAndNotDisposed = <ObjectRecord>[];
     _objects.notGCed.forEach((record) {

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -62,6 +62,7 @@ class ObjectTracker implements LeakProvider {
     required String trackedClass,
     required PhaseSettings phase,
   }) {
+    //print('!!!!! started tracking ${identityHashCode(object)}');
     throwIfDisposed();
     if (phase.isLeakTrackingPaused || switches.isObjectTrackingDisabled) return;
 
@@ -78,6 +79,7 @@ class ObjectTracker implements LeakProvider {
   }
 
   void _onObjectGarbageCollected(Object record) {
+    //print('!!!!! garbage collected ${identityHashCode(record.hashCode)}');
     if (disposed) return;
     if (record is! ObjectRecord) throw 'record should be $ObjectRecord.';
 

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -84,6 +84,10 @@ class ObjectTracker implements LeakProvider {
     _objects.assertRecordIntegrity(record);
     record.setGCed(_gcCounter.gcCount, clock.now());
 
+    _declareNotDisposedLeak(record);
+  }
+
+  void _declareNotDisposedLeak(ObjectRecord record) {
     if (record.isGCedLateLeak(disposalTime, numberOfGcCycles)) {
       _objects.gcedLateLeaks.add(record);
     } else if (record.isNotDisposedLeak) {
@@ -98,9 +102,16 @@ class ObjectTracker implements LeakProvider {
     _objects.assertRecordIntegrity(record);
   }
 
-  void markAllNotDisposedGCed() {
+  /// Declares all not disposed objects as leaks, even if they are not GCed yet.
+  ///
+  /// Is used to make sure all disposables are disposed by the the end of the test.
+  void declareAllNotDisposedAsLeaks() {
     throwIfDisposed();
-    _objects.notGCed.forEach((record) => _onObjectGarbageCollected(record));
+    final notGCedAndNotDisposed = <ObjectRecord>[];
+    _objects.notGCed.forEach((record) {
+      if (!record.isDisposed) notGCedAndNotDisposed.add(record);
+    });
+    notGCedAndNotDisposed.forEach(_declareNotDisposedLeak);
   }
 
   void dispatchDisposal(

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -62,7 +62,6 @@ class ObjectTracker implements LeakProvider {
     required String trackedClass,
     required PhaseSettings phase,
   }) {
-    //print('!!!!! started tracking ${identityHashCode(object)}');
     throwIfDisposed();
     if (phase.isLeakTrackingPaused || switches.isObjectTrackingDisabled) return;
 
@@ -79,7 +78,6 @@ class ObjectTracker implements LeakProvider {
   }
 
   void _onObjectGarbageCollected(Object record) {
-    //print('!!!!! garbage collected ${identityHashCode(record.hashCode)}');
     if (disposed) return;
     if (record is! ObjectRecord) throw 'record should be $ObjectRecord.';
 
@@ -98,6 +96,11 @@ class ObjectTracker implements LeakProvider {
     _objects.notGCedDisposedLateCollected.remove(record);
 
     _objects.assertRecordIntegrity(record);
+  }
+
+  void markAllNotDisposedGCed() {
+    throwIfDisposed();
+    _objects.notGCed.forEach((record) => _onObjectGarbageCollected(record));
   }
 
   void dispatchDisposal(

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -107,6 +107,8 @@ class ObjectTracker implements LeakProvider {
   /// Is used to make sure all disposables are disposed by the the end of the test.
   void declareAllNotDisposedAsLeaks() {
     throwIfDisposed();
+    // We need this temporary storage to avoid errror 'concurrent modification during iteration'
+    // for internal iterables in `_objects.notGCed`.
     final notGCedAndNotDisposed = <ObjectRecord>[];
     _objects.notGCed.forEach((record) {
       if (!record.isDisposed) notGCedAndNotDisposed.add(record);

--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
@@ -210,4 +210,12 @@ abstract class LeakTracking {
 
     await (result ?? Future.value());
   }
+
+  /// Converts all not disposed objects to leaks.
+  ///
+  /// Should be invoked after test execution, to detect
+  /// not disposed objects, that are not GCed yet.
+  static void convertNotDisposedToLeaks() {
+    _leakTracker?.objectTracker.markAllNotDisposedGCed();
+  }
 }

--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
@@ -211,11 +211,11 @@ abstract class LeakTracking {
     await (result ?? Future.value());
   }
 
-  /// Converts all not disposed objects to leaks.
+  /// Declares all not disposed objects as leaks.
   ///
   /// Should be invoked after test execution, to detect
-  /// not disposed objects, that are not GCed yet.
-  static void convertNotDisposedToLeaks() {
+  /// not disposed objects, even if they are not GCed yet.
+  static void declareNotDisposedObjectsAsLeaks() {
     _leakTracker?.objectTracker.declareAllNotDisposedAsLeaks();
   }
 }

--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
@@ -216,6 +216,6 @@ abstract class LeakTracking {
   /// Should be invoked after test execution, to detect
   /// not disposed objects, that are not GCed yet.
   static void convertNotDisposedToLeaks() {
-    _leakTracker?.objectTracker.markAllNotDisposedGCed();
+    _leakTracker?.objectTracker.declareAllNotDisposedAsLeaks();
   }
 }

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker
-version: 9.0.7
+version: 9.0.8
 description: A framework for memory leak tracking for Dart and Flutter applications.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker
 

--- a/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
+++ b/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
@@ -1,6 +1,9 @@
-# 1.0.5
+# 1.0.6
 
 * If an object is not disposed by the end of testing, mark it as notDisposed.
+
+# 1.0.5
+
 * Bump version of SDK to 3.1.2.
 
 # 1.0.4

--- a/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
+++ b/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.5
+
+* If an object is not disposed by the end of testing, mark it as notDisposed.
+
 # 1.0.4
 
 * Update matcher for memory events to handle async callbacks.

--- a/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
+++ b/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
@@ -66,8 +66,9 @@ void configureLeakTrackingTearDown({
 Future<void> _tearDownTestingWithLeakTracking(LeaksCallback? onLeaks) async {
   if (!LeakTracking.isStarted) return;
   if (!_isPlatformSupported) return;
-
   MemoryAllocations.instance.removeListener(_flutterEventToLeakTracker);
+
+  LeakTracking.convertNotDisposedToLeaks();
   await forceGC(fullGcCycles: _leakTrackingTestSettings.numberOfGcCycles);
   // This delay is needed to make sure all disposed and not GCed object are
   // declared as leaks, and thus there is no flakiness in tests.

--- a/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
+++ b/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
@@ -68,7 +68,7 @@ Future<void> _tearDownTestingWithLeakTracking(LeaksCallback? onLeaks) async {
   if (!_isPlatformSupported) return;
   MemoryAllocations.instance.removeListener(_flutterEventToLeakTracker);
 
-  LeakTracking.convertNotDisposedToLeaks();
+  LeakTracking.declareNotDisposedObjectsAsLeaks();
   await forceGC(fullGcCycles: _leakTrackingTestSettings.numberOfGcCycles);
   // This delay is needed to make sure all disposed and not GCed object are
   // declared as leaks, and thus there is no flakiness in tests.

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker_flutter_testing
-version: 1.0.4
+version: 1.0.5
 description: Flutter specific helpers for dart memory leak tracking.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_flutter_testing
 

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker_flutter_testing
-version: 1.0.5
+version: 1.0.6
 description: Flutter specific helpers for dart memory leak tracking.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_flutter_testing
 

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/failure_test.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/failure_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+
+late String twoControllers;
+
+/// Verification for the tests happens in flutter_test_config.dart.
+void main() {
+  testWidgetsWithLeakTracking(
+      twoControllers = 'Two not disposed controllers results in two leaks.',
+      (tester) async {
+    // ignore: unused_local_variable
+    final TextEditingController controller = TextEditingController();
+    print('!!!! ${identityHashCode(controller)}');
+    // ignore: unused_local_variable
+    final FocusNode focusNode = FocusNode(debugLabel: 'Test Node');
+
+    await tester.pumpWidget(
+      Material(
+        child: MaterialApp(
+          onGenerateRoute: (RouteSettings settings) {
+            return PageRouteBuilder<void>(
+              settings: settings,
+              pageBuilder: (BuildContext context, Animation<double> input,
+                  Animation<double> out) {
+                return Focus(
+                  child: TextField(
+                    autofocus: true,
+                    focusNode: focusNode,
+                    controller: controller,
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(focusNode.hasPrimaryFocus, isTrue);
+  });
+}

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/failure_test.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/failure_test.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 late String twoControllers;
@@ -16,33 +14,8 @@ void main() {
       (tester) async {
     // ignore: unused_local_variable
     final TextEditingController controller = TextEditingController();
-    print('!!!! ${identityHashCode(controller)}');
+
     // ignore: unused_local_variable
     final FocusNode focusNode = FocusNode(debugLabel: 'Test Node');
-
-    await tester.pumpWidget(
-      Material(
-        child: MaterialApp(
-          onGenerateRoute: (RouteSettings settings) {
-            return PageRouteBuilder<void>(
-              settings: settings,
-              pageBuilder: (BuildContext context, Animation<double> input,
-                  Animation<double> out) {
-                return Focus(
-                  child: TextField(
-                    autofocus: true,
-                    focusNode: focusNode,
-                    controller: controller,
-                  ),
-                );
-              },
-            );
-          },
-        ),
-      ),
-    );
-    await tester.pump();
-
-    expect(focusNode.hasPrimaryFocus, isTrue);
   });
 }

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker/leak_tracker.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'failure_test.dart';
+
 /// The test configuration for each test library in this directory.
 ///
 /// See https://api.flutter.dev/flutter/flutter_test/flutter_test-library.html.
@@ -19,7 +21,11 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   tearDownAll(() async {
     final theLeaks = leaks;
     if (theLeaks == null) throw 'leaks should be detected';
-    expect(theLeaks.notDisposed, hasLength(2));
+
+    expect(
+      theLeaks.notDisposed.where((l) => l.phase == twoControllers),
+      hasLength(2),
+    );
   });
 
   configureLeakTrackingTearDown(

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker/leak_tracker.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+
+/// Test configuration for each test library in this directory.
+///
+/// See https://api.flutter.dev/flutter/flutter_test/flutter_test-library.html.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  Leaks? leaks;
+
+  // This tear down should be set before leak tracking tear down in
+  // order to happen after it and verify that leaks are found.
+  tearDownAll(() async {
+    final theLeaks = leaks;
+    if (theLeaks == null) throw 'leaks should be detected';
+    print(theLeaks.notDisposed.length);
+  });
+
+  configureLeakTrackingTearDown(
+    configureOnce: true,
+    onLeaks: (l) => leaks = l,
+  );
+
+  setUpAll(() {
+    LeakTracking.warnForUnsupportedPlatforms = false;
+  });
+
+  await testMain();
+}

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker/leak_tracker.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-/// Test configuration for each test library in this directory.
+/// The test configuration for each test library in this directory.
 ///
 /// See https://api.flutter.dev/flutter/flutter_test/flutter_test-library.html.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/failing_tests/flutter_test_config.dart
@@ -19,7 +19,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   tearDownAll(() async {
     final theLeaks = leaks;
     if (theLeaks == null) throw 'leaks should be detected';
-    print(theLeaks.notDisposed.length);
+    expect(theLeaks.notDisposed, hasLength(2));
   });
 
   configureLeakTrackingTearDown(


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/135716

This is follow up to fix leak tracker flakiness: https://github.com/flutter/flutter/pull/135394

This PR resolves false negatives, so it is breaking change.
Objects, not disposed by the end of the test, should be marked as leaks, even if they are not GCed yet.

The upgrade to this version should be handled manually, because it may result in some tests failing.
