### PR TITLE
Enable and fix strict-casts analyzer mode

### DIFF
--- a/pkgs/leak_tracker/analysis_options.yaml
+++ b/pkgs/leak_tracker/analysis_options.yaml
@@ -3,7 +3,7 @@ include: package:flutter_lints/flutter.yaml
 
 analyzer:
   language:
-    #strict-casts: true # 14 issues
+    strict-casts: true
     #strict-inference: true # 34 issues
     #strict-raw-types: true # 103 issues
   errors:

--- a/pkgs/leak_tracker/lib/src/devtools_integration/_protocol.dart
+++ b/pkgs/leak_tracker/lib/src/devtools_integration/_protocol.dart
@@ -63,14 +63,15 @@ Map<String, dynamic> sealEnvelope(Object message, Channel channel) {
   };
 }
 
-/// Deserialize [message] into an opbejct of a right type.
-Object openEnvelope(
+/// Deserialize [message] into an object with the specified [T] type.
+T openEnvelope<T>(
   Map<String, dynamic> message,
   Channel channel,
 ) {
-  final envelope = _envelopeByCode(message[_JsonFields.envelopeCode] as String);
+  final envelope =
+      _envelopeByCode<T>(message[_JsonFields.envelopeCode] as String);
   assert(envelope.channel == channel);
-  return envelope.decode(message[_JsonFields.content]);
+  return envelope.decode(message[_JsonFields.content] as Map<String, Object?>);
 }
 
 /// Information necessary to serialize and deserialize an instance of type [T],

--- a/pkgs/leak_tracker/lib/src/devtools_integration/delivery.dart
+++ b/pkgs/leak_tracker/lib/src/devtools_integration/delivery.dart
@@ -20,10 +20,10 @@ class RequestToApp<T extends Object> {
   RequestToApp(this.message);
 
   RequestToApp.fromRequestParameters(Map<String, String> parameters)
-      : message = openEnvelope(
-          jsonDecode(parameters[_JsonFields.content]!),
+      : message = openEnvelope<T>(
+          jsonDecode(parameters[_JsonFields.content]!) as Map<String, Object?>,
           Channel.requestToApp,
-        ) as T;
+        );
 
   Map<String, String> toRequestParameters() {
     return {
@@ -39,7 +39,7 @@ class ResponseFromApp<T extends Object> {
   ResponseFromApp(this.message);
 
   ResponseFromApp.fromJson(Map<String, dynamic> json)
-      : this(openEnvelope(json, Channel.responseFromApp) as T);
+      : this(openEnvelope<T>(json, Channel.responseFromApp));
 
   ResponseFromApp.fromServiceResponse(Response response)
       : this.fromJson(response.json!);
@@ -59,7 +59,7 @@ class EventFromApp<T extends Object> {
   EventFromApp(this.message);
 
   EventFromApp.fromJson(Map<String, dynamic> json)
-      : this(openEnvelope(json, Channel.eventFromApp) as T);
+      : this(openEnvelope<T>(json, Channel.eventFromApp));
 
   static EventFromApp? fromVmServiceEvent(Event event) {
     if (event.extensionKind != memoryLeakTrackingExtensionName) return null;

--- a/pkgs/leak_tracker/lib/src/devtools_integration/primitives.dart
+++ b/pkgs/leak_tracker/lib/src/devtools_integration/primitives.dart
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_primitives/model.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_primitives/model.dart
@@ -315,9 +315,9 @@ class ValueSampler {
   ValueSampler({
     required this.initialValue,
     required this.samples,
-    required deltaAvg,
+    required double deltaAvg,
     required this.deltaMax,
-    required absAvg,
+    required double absAvg,
     required this.absMax,
   })  : _sealed = true,
         _absSum = absAvg * samples,

--- a/pkgs/leak_tracker/lib/src/shared/shared_model.dart
+++ b/pkgs/leak_tracker/lib/src/shared/shared_model.dart
@@ -52,7 +52,10 @@ class LeakSummary {
 
   factory LeakSummary.fromJson(Map<String, dynamic> json) => LeakSummary(
         (json[_JsonFields.totals] as Map<String, dynamic>).map(
-          (key, value) => MapEntry(LeakType.byName(key), int.parse(value)),
+          (key, value) => MapEntry(
+            LeakType.byName(key),
+            int.parse(value as String),
+          ),
         ),
         time:
             DateTime.fromMillisecondsSinceEpoch(json[_JsonFields.time] as int),
@@ -139,12 +142,11 @@ class LeakReport {
   });
 
   factory LeakReport.fromJson(Map<String, dynamic> json) => LeakReport(
-        type: json[_JsonFields.type],
-        context: (json[_JsonFields.context] as Map<String, dynamic>? ?? {})
-            .cast<String, dynamic>(),
-        code: json[_JsonFields.code],
-        trackedClass: json[_JsonFields.trackedClass] ?? '',
-        phase: json[_JsonFields.phase],
+        type: json[_JsonFields.type] as String,
+        context: json[_JsonFields.context] as Map<String, dynamic>? ?? {},
+        code: json[_JsonFields.code] as int,
+        trackedClass: json[_JsonFields.trackedClass] as String? ?? '',
+        phase: json[_JsonFields.phase] as String?,
       );
 
   /// Information about the leak that can help in troubleshooting.

--- a/pkgs/leak_tracker/test/tests/leak_tracking/_leak_checker_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/_leak_checker_test.dart
@@ -202,7 +202,7 @@ class _ListenedSink {
 
   void checkStoreAndClear(List<LeakSummary> items) {
     expect(store, hasLength(items.length));
-    for (final i in Iterable.generate(store.length)) {
+    for (final i in Iterable<int>.generate(store.length)) {
       expect(store[i].toMessage(), contains(items[i].toMessage()));
     }
     store.clear();
@@ -217,7 +217,7 @@ class _MockStdoutSink implements StdoutSummarySink {
 
   void checkStoreAndClear(List<LeakSummary> items) {
     expect(store, hasLength(items.length));
-    for (final i in Iterable.generate(store.length)) {
+    for (final i in Iterable<int>.generate(store.length)) {
       expect(store[i].toMessage(), contains(items[i].toMessage()));
     }
     store.clear();
@@ -232,7 +232,7 @@ class _MockDevToolsSink implements DevToolsSummarySink {
 
   void checkStoreAndClear(List<LeakSummary> items) {
     expect(store, hasLength(items.length));
-    for (final i in Iterable.generate(store.length)) {
+    for (final i in Iterable<int>.generate(store.length)) {
       expect(store[i].toMessage(), contains(items[i].toMessage()));
     }
     store.clear();

--- a/pkgs/leak_tracker_flutter_testing/lib/src/matchers.dart
+++ b/pkgs/leak_tracker_flutter_testing/lib/src/matchers.dart
@@ -62,7 +62,7 @@ class _AreCreateAndDispose extends Matcher {
     Map matchState,
     bool verbose,
   ) {
-    return mismatchDescription..add(matchState[_key]);
+    return mismatchDescription..add(matchState[_key] as String);
   }
 
   @override

--- a/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/baselining_test.dart
+++ b/pkgs/leak_tracker_flutter_testing/test/tests/end_to_end/baselining_test.dart
@@ -47,7 +47,7 @@ void main() {
     ),
   );
 
-  for (var i in Iterable.generate(10)) {
+  for (var i in Iterable<int>.generate(10)) {
     testWidgetsWithLeakTracking(
       'baselining with multiple runs',
       (widgetTester) async {


### PR DESCRIPTION
Enables the `strict-casts` [analyzer language mode](https://dart.dev/tools/analysis#enabling-additional-type-checks) and fixes the resulting diagnostics.

Works towards the TODO in the `analysis_options.yaml` file of switching to `package:dart_flutter_team_lints` which enables this by default.
