### PR TITLE
Fix. typo in leak_tracking.dart

### DIFF
--- a/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/leak_tracking.dart
@@ -116,7 +116,7 @@ abstract class LeakTracking {
 
   /// Dispatches object creation to the leak tracker.
   ///
-  /// Use [context] to provide additional information, that may help in leek troubleshooting.
+  /// Use [context] to provide additional information, that may help in leak troubleshooting.
   /// The value must be serializable.
   static void dispatchObjectCreated({
     required String library,


### PR DESCRIPTION
### Description
This PR fixes typo in `leak_tracking.dart` by changing `leek` to `leak` .


## What type of PR is this?

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
