### PR TITLE
Enable `strict-inference` analysis language mode

### DIFF
--- a/examples/autosnapshotting/integration_test/app_test.dart
+++ b/examples/autosnapshotting/integration_test/app_test.dart
@@ -38,7 +38,8 @@ void main() {
       await tester.tap(theButton);
       await tester.pumpAndSettle();
     }
-    await tester.runAsync(() => Future.delayed(const Duration(seconds: 5)));
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(seconds: 5)));
     expect(pageState.snapshots.length, greaterThan(0));
 
     // Take second threshold
@@ -49,7 +50,8 @@ void main() {
       await tester.tap(theButton);
       await tester.pumpAndSettle();
     }
-    await tester.runAsync(() => Future.delayed(const Duration(seconds: 5)));
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(seconds: 5)));
     expect(pageState.snapshots.length, snapshotsLength + 1);
 
     // Check the directory limit is respected.
@@ -57,10 +59,11 @@ void main() {
         config.autoSnapshottingConfig!.directorySizeLimitMb.mbToBytes()) {
       await tester.tap(theButton);
       await tester.pumpAndSettle();
-      await tester.runAsync(() => Future.delayed(const Duration(seconds: 1)));
+      await tester
+          .runAsync(() => Future<void>.delayed(const Duration(seconds: 1)));
     }
     snapshotsLength = pageState.snapshots.length;
-    for (var _ in Iterable.generate(10)) {
+    for (var _ in Iterable<void>.generate(10)) {
       await tester.tap(theButton);
       await tester.pumpAndSettle();
     }

--- a/pkgs/leak_tracker/analysis_options.yaml
+++ b/pkgs/leak_tracker/analysis_options.yaml
@@ -4,7 +4,7 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   language:
     strict-casts: true
-    #strict-inference: true # 34 issues
+    strict-inference: true
     #strict-raw-types: true # 103 issues
   errors:
     # treat missing required parameters as a warning (not a hint)

--- a/pkgs/leak_tracker/lib/src/shared/_util.dart
+++ b/pkgs/leak_tracker/lib/src/shared/_util.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 /// This function is better than `as`, because `as` does not provide callstack on failure.
-T cast<T>(value) {
+T cast<T>(Object? value) {
   if (value is T) return value;
   throw ArgumentError(
     '$value is of type ${value.runtimeType} that is not subtype of $T',

--- a/pkgs/leak_tracker/test/test_infra/data/messages.dart
+++ b/pkgs/leak_tracker/test/test_infra/data/messages.dart
@@ -25,7 +25,7 @@ final messages = [
 ];
 
 void verifyTestsCoverAllEnvelopes() {
-  final nonCoveredEnvelopes = Set.from(envelopes.map((e) => e.type));
+  final nonCoveredEnvelopes = Set.of(envelopes.map((e) => e.type));
   for (final message in messages) {
     nonCoveredEnvelopes.remove(message.runtimeType);
   }

--- a/pkgs/leak_tracker/test/tests/devtools_integration/_envelopes_test.dart
+++ b/pkgs/leak_tracker/test/tests/devtools_integration/_envelopes_test.dart
@@ -13,12 +13,12 @@ void main() {
   });
 
   test('each code matches exactly one envelope', () {
-    final codesInEnvelopes = Set.from(envelopes.map((e) => e.code));
+    final codesInEnvelopes = Set.of(envelopes.map((e) => e.code));
     expect(codesInEnvelopes, hasLength(Codes.values.length));
   });
 
   test('envelopes are unique by type', () {
-    final types = Set.from(envelopes.map((e) => e.type));
+    final types = Set.of(envelopes.map((e) => e.type));
     expect(types, hasLength(envelopes.length));
   });
 
@@ -26,7 +26,8 @@ void main() {
     test('envelopes preserve original type', () {
       final envelope = envelopeByType(message.runtimeType);
       final envelopedMessage = sealEnvelope(message, envelope.channel);
-      final openedMessage = openEnvelope(envelopedMessage, envelope.channel);
+      final openedMessage =
+          openEnvelope<Object>(envelopedMessage, envelope.channel);
       expect(openedMessage.runtimeType, message.runtimeType);
     });
   }

--- a/pkgs/leak_tracker/test/tests/leak_tracking/_leak_checker_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/_leak_checker_test.dart
@@ -85,33 +85,33 @@ void main() {
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
 
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
 
     // Report leaks and make sure they signaled one time.
     leakProvider.value = _SummaryValues.nonZero;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     stdout.checkStoreAndClear([_SummaryValues.nonZero]);
     devtools.checkStoreAndClear([_SummaryValues.nonZero]);
 
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
 
     // Report the same leak totals and make sure there is no signals.
     leakProvider.value = _SummaryValues.nonZeroCopy;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
 
     // Drop totals and check signal.
     leakProvider.value = _SummaryValues.zero;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     stdout.checkStoreAndClear([_SummaryValues.zero]);
     devtools.checkStoreAndClear([_SummaryValues.zero]);
 
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
   });
@@ -130,38 +130,38 @@ void main() {
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);
 
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);
 
     // Report leaks and make sure they signaled one time.
     leakProvider.value = _SummaryValues.nonZero;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     listened.checkStoreAndClear([_SummaryValues.nonZero]);
 
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);
 
     // Report the same leak totals and make sure there is no signals.
     leakProvider.value = _SummaryValues.nonZeroCopy;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);
 
     // Drop totals and check signal.
     leakProvider.value = _SummaryValues.zero;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     listened.checkStoreAndClear([_SummaryValues.zero]);
 
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);
@@ -177,14 +177,14 @@ void main() {
     );
 
     // Make sure there is no leaks.
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);
 
     // Report leaks and make sure did not signal.
     leakProvider.value = _SummaryValues.nonZero;
-    await Future.delayed(doublePeriod);
+    await Future<void>.delayed(doublePeriod);
     expect(stdout.store, isEmpty);
     expect(devtools.store, isEmpty);
     expect(listened.store, isEmpty);

--- a/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/_object_tracker_test.dart
@@ -158,7 +158,7 @@ void main() {
     });
 
     test('uses finalizer.', () {
-      const theObject = [];
+      const theObject = <void>[];
       tracker.startTracking(
         theObject,
         context: null,
@@ -173,7 +173,7 @@ void main() {
 
     test('does not false positive.', () {
       // Define object and time.
-      const theObject = [];
+      const theObject = <void>[];
       var time = DateTime(2000);
 
       // Start tracking.
@@ -198,7 +198,7 @@ void main() {
 
     test('tracks ${LeakType.notDisposed}.', () async {
       // Define object.
-      const theObject = [];
+      const theObject = <void>[];
 
       // Start tracking and GC.
       tracker.startTracking(
@@ -215,7 +215,7 @@ void main() {
 
     test('tracks ${LeakType.notGCed}.', () async {
       // Define object and time.
-      const theObject = [];
+      const theObject = <void>[];
       var time = DateTime(2000);
 
       // Start tracking and dispose.
@@ -241,7 +241,7 @@ void main() {
 
     test('tracks ${LeakType.gcedLate}.', () async {
       // Define object and time.
-      const theObject = [];
+      const theObject = <void>[];
       var time = DateTime(2000);
 
       // Start tracking and dispose.
@@ -268,7 +268,7 @@ void main() {
 
     test('tracks ${LeakType.gcedLate} lifecycle accurately.', () async {
       // Define object and time.
-      const theObject = [];
+      const theObject = <void>[];
       var time = DateTime(2000);
 
       // Start tracking and dispose.
@@ -298,7 +298,7 @@ void main() {
 
     test('collects context accurately.', () async {
       // Define object and time.
-      const theObject = [];
+      const theObject = <void>[];
       var time = DateTime(2000);
 
       // Start tracking and dispose.
@@ -321,7 +321,7 @@ void main() {
       await withClock(Clock.fixed(time), () async {
         final leaks = await tracker.collectLeaks();
         final context = leaks.notGCed.first.context!;
-        for (final i in Iterable.generate(3)) {
+        for (final i in Iterable<int>.generate(3)) {
           expect(context[i.toString()], i);
         }
       });
@@ -348,7 +348,7 @@ void main() {
 
     test('collects stack traces.', () async {
       // Define object and time.
-      const theObject = [];
+      const theObject = <void>[];
       var time = DateTime(2000);
 
       // Start tracking and dispose.

--- a/pkgs/leak_tracker/test/tests/leak_tracking/orchestration_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/orchestration_test.dart
@@ -30,7 +30,7 @@ void main() {
       const rounds = 100;
       final sw = Stopwatch()..start();
 
-      for (var _ in Iterable.generate(rounds)) {
+      for (var _ in Iterable<void>.generate(rounds)) {
         await forceGC();
       }
 

--- a/pkgs/leak_tracker/test/tests/leak_tracking/platform_test.dart
+++ b/pkgs/leak_tracker/test/tests/leak_tracking/platform_test.dart
@@ -13,7 +13,7 @@ Future<WeakReference<Object>> _createTrackedObject(
   final theObject = Iterable.generate(1000, (_) => DateTime.now());
 
   // Delay to increase chances for the object to get to old gc space.
-  await Future.delayed(const Duration(milliseconds: 10));
+  await Future<void>.delayed(const Duration(milliseconds: 10));
 
   finalizer.attach(theObject, identityHashCode(theObject));
   return WeakReference(theObject);
@@ -42,7 +42,7 @@ void main() {
     while (reachabilityBarrier <= barrier + 2) {
       _allocateMemory();
       // Delay to give space to garbage collector.
-      await Future.delayed(const Duration());
+      await Future<void>.delayed(const Duration());
     }
 
     expect(finalized, true);

--- a/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
+++ b/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
@@ -72,7 +72,7 @@ Future<void> _tearDownTestingWithLeakTracking(LeaksCallback? onLeaks) async {
   await forceGC(fullGcCycles: _leakTrackingTestSettings.numberOfGcCycles);
   // This delay is needed to make sure all disposed and not GCed object are
   // declared as leaks, and thus there is no flakiness in tests.
-  await Future.delayed(_leakTrackingTestSettings.disposalTime);
+  await Future<void>.delayed(_leakTrackingTestSettings.disposalTime);
   final leaks = await LeakTracking.collectLeaks();
 
   LeakTracking.stop();


### PR DESCRIPTION
Enables the [`strict-inference` analysis language mode](https://dart.dev/tools/analysis#enabling-additional-type-checks) to get this repository closer to enabling `package:dart_flutter_team_lints`.