### PR TITLE
fix: typos in finalizer, formatting, primitive.dart

### DIFF
--- a/pkgs/leak_tracker/lib/src/devtools_integration/primitives.dart
+++ b/pkgs/leak_tracker/lib/src/devtools_integration/primitives.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Name of extension to integrate the leak tracker with DevDools.
+/// Name of extension to integrate the leak tracker with DevTools.
 const String memoryLeakTrackingExtensionName = 'ext.dart.memoryLeakTracking';
 
 /// Version of protocol, executed by the application.

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_primitives/_finalizer.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_primitives/_finalizer.dart
@@ -4,7 +4,7 @@
 
 typedef ObjectGcCallback = void Function(Object token);
 
-/// Finilizer builder to mock standard [Finalizer].
+/// Finalizer builder to mock standard [Finalizer].
 typedef FinalizerBuilder = FinalizerWrapper Function(
   ObjectGcCallback onObjectGc,
 );

--- a/pkgs/leak_tracker/lib/src/shared/_formatting.dart
+++ b/pkgs/leak_tracker/lib/src/shared/_formatting.dart
@@ -53,7 +53,7 @@ String retainingPathToString(RetainingPath retainingPath) {
   return buffer.toString();
 }
 
-/// Proprties of [RetainingObject] that are needed in the object's formatting.
+/// Properties of [RetainingObject] that are needed in the object's formatting.
 enum RetainingObjectProperty {
   lib([
     ['value', 'class', 'library', 'name'],


### PR DESCRIPTION
### Description
This PR fixes typo in 
- `_finalizer.dart`.
- `_formatting.dart`.
- `primitives.dart`.


## What type of PR is this?

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
