### PR TITLE
use pubspec_overrides.yaml files to specify dependency_overrides

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: sh ./tool/analyze.sh
 
       - name: dart test
-        run: dart test test
+        run: dart test
         working-directory: pkgs/leak_tracker
 
       - name: flutter test

--- a/examples/autosnapshotting/pubspec.yaml
+++ b/examples/autosnapshotting/pubspec.yaml
@@ -1,6 +1,6 @@
 name: autosnapshotting
 description: A new Flutter project.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: none
 
 version: 1.0.0+1
 
@@ -25,4 +25,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-

--- a/examples/minimal_flutter/pubspec.yaml
+++ b/examples/minimal_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker_minimal_flutter_example
-publish_to: 'none'
+publish_to: none
 
 environment:
   sdk: ^3.0.0

--- a/pkgs/leak_tracker/example/pubspec.yaml
+++ b/pkgs/leak_tracker/example/pubspec.yaml
@@ -1,4 +1,5 @@
 name: leak_tracker_minimal_dart_example
+publish_to: none
 
 environment:
   sdk: ^3.0.0

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^3.0.0
-  layerlens:
-  leak_tracker_testing:
-    path: ../leak_tracker_testing
+  layerlens: ^1.0.0
+  leak_tracker_testing: any
   test: ^1.16.0

--- a/pkgs/leak_tracker/pubspec_overrides.yaml
+++ b/pkgs/leak_tracker/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  leak_tracker_testing:
+    path: ../leak_tracker_testing

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -17,9 +17,3 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^3.0.0
-
-dependency_overrides:
-  leak_tracker:
-    path: ../leak_tracker
-  leak_tracker_testing:
-    path: ../leak_tracker_testing

--- a/pkgs/leak_tracker_flutter_testing/pubspec_overrides.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  leak_tracker:
+    path: ../leak_tracker
+  leak_tracker_testing:
+    path: ../leak_tracker_testing

--- a/pkgs/leak_tracker_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_testing/pubspec.yaml
@@ -12,8 +12,4 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^3.0.0
-  layerlens:
-
-dependency_overrides:
-  leak_tracker:
-    path: ../leak_tracker
+  layerlens: ^1.0.0

--- a/pkgs/leak_tracker_testing/pubspec_overrides.yaml
+++ b/pkgs/leak_tracker_testing/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  leak_tracker:
+    path: ../leak_tracker


### PR DESCRIPTION
- use pubspec_overrides.yaml files to specify dependency_overrides

This makes for a cleaner story when we publish these packages.

Related, I would look to break the dependency from `leak_tracker` onto `leak_treacker_testing`. I think we should be able to test `leak_tracker` in isolation from `leak_treacker_testing`, and that will remove a use of dependency overrides in this repo.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
