### PR TITLE
reconcile the package descriptions with the readme file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # See
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*                   @polina-c @CoderDake
+* @polina-c @CoderDake

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This is a framework for detecting memory issues in Dart and Flutter applications
 
 | Package | Description | Version |
 | --- | --- | --- |
-| [leak_tracker](pkgs/leak_tracker/) | (work in progress, used by flutter_test) A framework for detecting memory issues for Dart and Flutter applications. | [![pub package](https://img.shields.io/pub/v/leak_tracker.svg)](https://pub.dev/packages/leak_tracker) |
-| [leak_tracker_testing](pkgs/leak_tracker_testing/) | (work in progress, used by flutter_test) Leak tracking helpers intended for usage in Dart and Flutter tests. | [![pub package](https://img.shields.io/pub/v/leak_tracker_testing.svg)](https://pub.dev/packages/leak_tracker_testing) |
-| [leak_tracker_flutter_testing](pkgs/leak_tracker_flutter_testing/) | Internal package to test leak tracker with Flutter. | [![pub package](https://img.shields.io/pub/v/leak_tracker_flutter_testing.svg)](https://pub.dev/packages/leak_tracker_flutter_testing) |
-| [memory_usage](pkgs/memory_usage/) | (experimental) Functionality to listen to memory usage events and to auto-snapshot memory in case of overuse. | [![pub package](https://img.shields.io/pub/v/memory_usage.svg)](https://pub.dev/packages/memory_usage) |
+| [leak_tracker](pkgs/leak_tracker/) | (work in progress, used by flutter_test) A framework for memory leak tracking for Dart and Flutter applications. | [![pub package](https://img.shields.io/pub/v/leak_tracker.svg)](https://pub.dev/packages/leak_tracker) |
+| [leak_tracker_testing](pkgs/leak_tracker_testing/) | (work in progress, used by flutter_test) Leak tracking code intended for usage in tests. | [![pub package](https://img.shields.io/pub/v/leak_tracker_testing.svg)](https://pub.dev/packages/leak_tracker_testing) |
+| [leak_tracker_flutter_testing](pkgs/leak_tracker_flutter_testing/) | An internal package to test leak tracking with Flutter. | [![pub package](https://img.shields.io/pub/v/leak_tracker_flutter_testing.svg)](https://pub.dev/packages/leak_tracker_flutter_testing) |
+| [memory_usage](pkgs/memory_usage/) | (experimental) A framework for memory usage tracking and snapshotting. | [![pub package](https://img.shields.io/pub/v/memory_usage.svg)](https://pub.dev/packages/memory_usage) |
 
 ## Guidance
 

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: leak_tracker_flutter_testing
 version: 1.0.10
-description: Flutter specific helpers for dart memory leak tracking.
+description: An internal package to test leak tracking with Flutter.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_flutter_testing
 
 environment:


### PR DESCRIPTION
- reconcile the package descriptions with the readme file

Make the package descriptions in the pubspec files the same as the ones in the readme. Feedback and worksmithing welcome (which description we want to use, ...).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
