### PR TITLE
fix: add missing on leak callback

### DIFF
--- a/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
+++ b/pkgs/leak_tracker_flutter_testing/lib/src/test_widgets.dart
@@ -87,7 +87,7 @@ void testWidgetsWithLeakTracking(
   dynamic tags,
   LeakTesting? leakTesting,
 }) {
-  configureLeakTrackingTearDown();
+  configureLeakTrackingTearDown(onLeaks: leakTesting?.onLeaks);
 
   Future<void> wrappedCallBack(WidgetTester tester) async {
     final settings = leakTesting ?? LeakTesting.settings;


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

The onLeaks callback did not get invoked.
