### PR TITLE
Update Dart SDK constraint to account for used dart:developer APIs

### DIFF
--- a/examples/autosnapshotting/pubspec.yaml
+++ b/examples/autosnapshotting/pubspec.yaml
@@ -2,7 +2,7 @@ name: autosnapshotting_example
 publish_to: none
 
 environment:
-  sdk: '>=3.1.2 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/examples/leak_tracking/pubspec.yaml
+++ b/examples/leak_tracking/pubspec.yaml
@@ -2,7 +2,7 @@ name: leak_tracker_minimal_flutter_example
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.0.2-wip
+
+* Require Dart SDK 3.2.0 or later.
+
 # 10.0.1
 
 * Allow to ignore objects created by test helpers.

--- a/pkgs/leak_tracker/CHANGELOG.md
+++ b/pkgs/leak_tracker/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 10.0.2-wip
+# 10.0.2
 
 * Require Dart SDK 3.2.0 or later.
 

--- a/pkgs/leak_tracker/example/pubspec.yaml
+++ b/pkgs/leak_tracker/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: leak_tracker_minimal_dart_example
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   leak_tracker: any

--- a/pkgs/leak_tracker/lib/src/leak_tracking/primitives/_retaining_path/_retaining_path_isolate.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/primitives/_retaining_path/_retaining_path_isolate.dart
@@ -23,7 +23,6 @@ Future<RetainingPath?> retainingPathImpl(
   if (objRef == null) return null;
 
   try {
-    // ignore: sdk_version_since
     final isolateId = Service.getIsolateId(Isolate.current);
 
     if (isolateId == null) {

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -1,10 +1,10 @@
 name: leak_tracker
-version: 10.0.1
+version: 10.0.2-wip
 description: A framework for memory leak tracking for Dart and Flutter applications.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker
 
 environment:
-  sdk: '>=3.1.2 <4.0.0'
+  sdk: ^3.2.0
 
 # All dependencies here will become Flutter transitive dependencies.
 # Follow the process when adding:

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker
-version: 10.0.2-wip
+version: 10.0.2
 description: A framework for memory leak tracking for Dart and Flutter applications.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker
 

--- a/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
+++ b/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4-wip
+
+* Require Dart SDK 3.2.0 or later.
+
 ## 2.0.3
 
 * Allow to ignore objects created by test helpers.
@@ -5,7 +9,7 @@
 
 ## 2.0.2
 
-* Replaced depracated `MemoryAllocations` with `FlutterMemoryAllocations`.
+* Replaced deprecated `MemoryAllocations` with `FlutterMemoryAllocations`.
 
 ## 2.0.1
 

--- a/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
+++ b/pkgs/leak_tracker_flutter_testing/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.4-wip
+## 2.0.4
 
 * Require Dart SDK 3.2.0 or later.
 

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker_flutter_testing
-version: 2.0.4-wip
+version: 2.0.4
 description: An internal package to test leak tracking with Flutter.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_flutter_testing
 

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -1,10 +1,10 @@
 name: leak_tracker_flutter_testing
-version: 2.0.3
+version: 2.0.4-wip
 description: An internal package to test leak tracking with Flutter.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_flutter_testing
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.18.0-18.0.pre.54'
 
 dependencies:

--- a/pkgs/leak_tracker_testing/CHANGELOG.md
+++ b/pkgs/leak_tracker_testing/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.3-wip
+## 2.0.3
 
 * Require Dart SDK 3.2.0 or later.
 

--- a/pkgs/leak_tracker_testing/CHANGELOG.md
+++ b/pkgs/leak_tracker_testing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3-wip
+
+* Require Dart SDK 3.2.0 or later.
+
 ## 2.0.2
 
 * Allow to ignore objects created by test helpers.

--- a/pkgs/leak_tracker_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_testing/pubspec.yaml
@@ -1,10 +1,10 @@
 name: leak_tracker_testing
-version: 2.0.2
+version: 2.0.3-wip
 description: Leak tracking code intended for usage in tests.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_testing
 
 environment:
-  sdk: '>=3.1.2 <4.0.0'
+  sdk: ^3.2.0
 
 # All dependencies here will become Flutter transitive dependencies.
 # Follow the process when adding:

--- a/pkgs/leak_tracker_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_testing/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker_testing
-version: 2.0.3-wip
+version: 2.0.3
 description: Leak tracking code intended for usage in tests.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker_testing
 

--- a/pkgs/memory_usage/example/pubspec.yaml
+++ b/pkgs/memory_usage/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: memory_usage_example
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   memory_usage: ^0.1.0

--- a/pkgs/memory_usage/pubspec.yaml
+++ b/pkgs/memory_usage/pubspec.yaml
@@ -4,7 +4,7 @@ description: A framework for memory usage tracking and snapshotting.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/memory_usage
 
 environment:
-  sdk: '>=3.1.2 <4.0.0'
+  sdk: ^3.2.0
 
 dependencies:
   path: ^1.8.3


### PR DESCRIPTION
Fixes https://github.com/dart-lang/leak_tracker/issues/201 since `package:leak_tracker` is using `dart:developer` APIs only available since Dart 3.2.0.

https://dart-review.googlesource.com/c/sdk/+/346200 adds `Since` information to the relevant APIs and more.