### PR TITLE
Update `testExecutable` signature in documentation

### DIFF
--- a/doc/leak_tracking/DETECT.md
+++ b/doc/leak_tracking/DETECT.md
@@ -38,14 +38,14 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 ...
 
-FutureOr<void> testExecutable(FutureOr<void> Function() testMain) {
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   LeakTesting.enable();
   LeakTesting.settings = LeakTesting.settings
     .withIgnored(createdByTestHelpers: true);
 
   ...
 
-  return testMain();
+  await testMain();
 }
 ```
 


### PR DESCRIPTION
In https://github.com/flutter/packages/pull/7546 I discovered that the signature of `testExecutable` should be 

```dart
Future<void> testExecutable(FutureOr<void> Function() testMain)
```

to be able to compile the tests for the chrome platform.

This PR updates the documentation.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
