### PR TITLE
Fix teardown logic in docs

### DIFF
--- a/doc/leak_tracking/TROUBLESHOOT.md
+++ b/doc/leak_tracking/TROUBLESHOOT.md
@@ -28,7 +28,7 @@ Follow the rules to avoid/fix notGCed and notDisposed leaks:
 
    ```dart
    final FocusNode focusNode = FocusNode();
-   addTearDown(focusNode.dispose());
+   addTearDown(focusNode.dispose);
    ```
 
 ## Known simple cases


### PR DESCRIPTION
Changed `addTearDown(aFocusNode.dispose());` to `addTearDown(aFocusNode.dispose);` in docs, since addTearDown accepts a callback.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
