### PR TITLE
fix: collectLeaks method - LeakType.gcedLate filters by wrong LeakType

### DIFF
--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -264,7 +264,7 @@ class ObjectTracker implements LeakProvider {
           .map((record) => record.toLeakReport())
           .toList(),
       LeakType.gcedLate: _objects.gcedLateLeaks
-          .where((record) => _leakFilter.shouldReport(LeakType.notGCed, record))
+          .where((record) => _leakFilter.shouldReport(LeakType.gcedLate, record))
           .map((record) => record.toLeakReport())
           .toList(),
     });

--- a/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/_object_tracker.dart
@@ -264,7 +264,9 @@ class ObjectTracker implements LeakProvider {
           .map((record) => record.toLeakReport())
           .toList(),
       LeakType.gcedLate: _objects.gcedLateLeaks
-          .where((record) => _leakFilter.shouldReport(LeakType.gcedLate, record))
+          .where(
+            (record) => _leakFilter.shouldReport(LeakType.gcedLate, record),
+          )
           .map((record) => record.toLeakReport())
           .toList(),
     });

--- a/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
@@ -124,8 +124,8 @@ class IgnoredLeaksSet {
 
 /// The total set of ignored leaks.
 ///
-/// - `experimentalNotGCed`: Ignore leaks that are not garbage-collected or collected late. 
-///   This is experimental and ignored by default.
+/// - `experimentalNotGCed`: Ignore leaks that are not garbage-collected or 
+///   collected late. This is experimental and ignored by default.
 ///
 /// - `notDisposed`: Ignore leaks that are not disposed.
 ///

--- a/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
@@ -128,7 +128,7 @@ class IgnoredLeaksSet {
 @immutable
 class IgnoredLeaks {
   const IgnoredLeaks({
-    this.experimentalNotGCed = const IgnoredLeaksSet.ignore(),
+    this.experimentalNotGCed = const IgnoredLeaksSet(),
     this.notDisposed = const IgnoredLeaksSet(),
     this.createdByTestHelpers = false,
     this.testHelperExceptions = const [],

--- a/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
@@ -131,8 +131,8 @@ class IgnoredLeaksSet {
 ///
 /// - `createdByTestHelpers`: Ignore leaks introduced by test helpers.
 ///
-/// - `testHelperExceptions`: If [createdByTestHelpers] is `true`, ignore leaks
-///   that are exception to that rule.
+/// - `testHelperExceptions`: If [createdByTestHelpers] rule is `true`, 
+/// set exceptions for that rule.
 @immutable
 class IgnoredLeaks {
   const IgnoredLeaks({

--- a/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
+++ b/pkgs/leak_tracker/lib/src/leak_tracking/primitives/model.dart
@@ -124,11 +124,19 @@ class IgnoredLeaksSet {
 
 /// The total set of ignored leaks.
 ///
-/// Includes both [experimentalNotGCed] and [notDisposed] leaks.
+/// - `experimentalNotGCed`: Ignore leaks that are not garbage-collected or collected late. 
+///   This is experimental and ignored by default.
+///
+/// - `notDisposed`: Ignore leaks that are not disposed.
+///
+/// - `createdByTestHelpers`: Ignore leaks introduced by test helpers.
+///
+/// - `testHelperExceptions`: If [createdByTestHelpers] is `true`, ignore leaks
+///   that are exception to that rule.
 @immutable
 class IgnoredLeaks {
   const IgnoredLeaks({
-    this.experimentalNotGCed = const IgnoredLeaksSet(),
+    this.experimentalNotGCed = const IgnoredLeaksSet.ignore(),
     this.notDisposed = const IgnoredLeaksSet(),
     this.createdByTestHelpers = false,
     this.testHelperExceptions = const [],

--- a/pkgs/leak_tracker/pubspec.yaml
+++ b/pkgs/leak_tracker/pubspec.yaml
@@ -1,5 +1,5 @@
 name: leak_tracker
-version: 11.0.0
+version: 11.0.1
 description: A framework for memory leak tracking for Dart and Flutter applications.
 repository: https://github.com/dart-lang/leak_tracker/tree/main/pkgs/leak_tracker
 

--- a/pkgs/leak_tracker_flutter_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_flutter_testing/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  leak_tracker: '>=10.0.8 <11.0.0'
+  leak_tracker: '>=10.0.8 <11.0.1'
   leak_tracker_testing: '>=3.0.1 <4.0.0'
   matcher: ^0.12.16
   meta: ^1.8.0

--- a/pkgs/leak_tracker_testing/pubspec.yaml
+++ b/pkgs/leak_tracker_testing/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Follow the process when adding:
 # https://github.com/flutter/flutter/blob/2be9b613099250cf8e84e1498a7624d9d2e04023/dev/bots/allowlist.dart#L13
 dependencies:
-  leak_tracker: '>=9.0.0 <11.0.0'
+  leak_tracker: '>=9.0.0 <11.0.1'
   matcher: ^0.12.16
   meta: ^1.11.0
 


### PR DESCRIPTION
Corrected the filter condition for gcedLate objects, which was mistakenly set to report under LeakType.notGCed. Now, gcedLateLeaks are correctly filtered under LeakType.gcedLate.

---

- [YES ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
